### PR TITLE
when replying after emptied the contents of the preview

### DIFF
--- a/app/assets/javascripts/topics.coffee
+++ b/app/assets/javascripts/topics.coffee
@@ -49,6 +49,7 @@ window.Topics =
       $("abbr.timeago",$("#replies .reply").last()).timeago()
       $("abbr.timeago",$("#replies .total")).timeago()
       $("#new_reply textarea").val('')
+      $("#preview").text('')
       App.notice(msg,'#reply')
     else
       App.alert(msg,'#reply')


### PR DESCRIPTION
如果回复主题的时候先点了“预览”查看回复话题的格式，之后再点击“提交回复”，这时输入框的内容被清空了，但预览的内容没被同时清空
