### PR TITLE
重复登录时，devise报告缺少zh-CN.devise.failure.already_authenticated错误

### DIFF
--- a/config/locales/devise.zh-CN.yml
+++ b/config/locales/devise.zh-CN.yml
@@ -10,6 +10,7 @@
       user:
         failure: '三方登陆过程异常，请重试。'
     failure:
+      already_authenticated: '您已经登录.'
       unauthenticated: '继续操作前请注册或者登录.'
       unconfirmed: '请先激活您的帐号'
       locked: '您的帐号已被锁定.'


### PR DESCRIPTION
修复translation missing: zh-CN.devise.failure.already_authenticated 问题
