### PR TITLE
楼主的名字不在AtReply列表里的Bug

### DIFF
--- a/app/assets/javascripts/topics.coffee
+++ b/app/assets/javascripts/topics.coffee
@@ -181,17 +181,17 @@ $(document).ready ->
   # @ Reply
   logins = []
   login_exists = []
-  if $("#topic_show .leader .name a").length > 0
+  if ($author = $("#topic_show .leader a[data-author]")).length > 0
     author_val =
-      login : $("#topic_show .leader .name a").text(),
-      name : $("#topic_show .leader .name a").data('name')
+      login : $author.text()
+      name  : $author.data('name')
     logins.push(author_val)
     login_exists.push(author_val.login)
   $('#replies span.name a').each (idx) ->
     val =
       login : $(this).text()
-      name : $(this).data('name')
-    if $.inArray(val.login,login_exists) < 0
+      name  : $(this).data('name')
+    if $.inArray(val.login, login_exists) < 0
       login_exists.push(val.login)
       logins.push(val)
   App.atReplyable("textarea", logins)

--- a/app/views/topics/_topic_info.html.erb
+++ b/app/views/topics/_topic_info.html.erb
@@ -6,7 +6,7 @@
   <div class="info leader">
     <%= render_node_name(topic.node_name,topic.node_id) %>
     •
-    <%= user_name_tag(topic.user) %>
+    <%= user_name_tag(topic.user, :data => {:author => true}) %>
     •
     <%= raw t("common.created_at", :time => timeago(topic.created_at))%>
     <% if !topic.last_reply_user_login.blank? %>


### PR DESCRIPTION
在先前的一个commit中，topic info里的html结构有改动，导致之前查询楼主名字的selector失效了。

https://github.com/ruby-china/ruby-china/commit/85d9775480200b3335a126824cc336d7ebce1add

这个Pull Request里包含了这个Bugfix。

注意，merge之前要好好测试一下，我本地一直跑不起来，所以...
