### PR TITLE
keep travis build green, fix ruby syntax indent typo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,10 +96,6 @@ group :development, :test do
   gem 'thin'
 end
 
-group :test do
-  gem 'mock_redis'
-end
-
 group :production do
   gem 'dalli', '1.1.1'
   gem 'unicorn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,6 @@ GEM
     mime-types (1.19)
     mini_magick (3.3)
       subexec (~> 0.1.0)
-    mock_redis (0.5.2)
     mongoid (3.0.1)
       activemodel (~> 3.1)
       moped (~> 1.1.1)
@@ -361,7 +360,6 @@ DEPENDENCIES
   md_emoji
   memcache-client (= 1.8.5)
   mini_magick (= 3.3)
-  mock_redis
   mongoid (= 3.0.1)
   mongoid_auto_increment_id (= 0.5.0)
   mongoid_colored_logger!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-
-Howto remove test dependencies from rspec cases
-
 ## Ruby China
 
 This is the source code of [Ruby China](http://ruby-china.org) website.

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -3,15 +3,10 @@ require "redis-namespace"
 require "redis/objects"
 require 'sidekiq/middleware/client/unique_jobs'
 require 'sidekiq/middleware/server/unique_jobs'
-require 'mock_redis'
 
 redis_config = YAML.load_file("#{Rails.root}/config/redis.yml")[Rails.env]
 
-Redis::Objects.redis = if Rails.env.eql?('test')
-                         MockRedis.new
-                       else
-                         Redis.new(:host => redis_config['host'], :port => redis_config['port'])
-                       end
+Redis::Objects.redis = Redis.new(:host => redis_config['host'], :port => redis_config['port'])
 
 sidekiq_url = "redis://#{redis_config['host']}:#{redis_config['port']}/0"
 Sidekiq.configure_server do |config|


### PR DESCRIPTION
1. keep travis build green.
2. fix a file's ruby syntax indent typo
   3.Fixed Regexp warning: character class has duplicated range

\d is redundant, \w is [a-zA-Z0-9_]
    \d is any digit. So \w\d would be expanded to [a-zA-Z0-9_0-9]
