### PR TITLE
修正记事本 preview 下 h1 标签右对齐的小 bug

### DIFF
--- a/app/assets/stylesheets/front.scss
+++ b/app/assets/stylesheets/front.scss
@@ -85,6 +85,9 @@
     }
     .buttons { margin-top:30px; text-align:right;}
   }
+  .preview {
+    h1 { text-align:left; }
+  }
 }
 
 .sidebar {


### PR DESCRIPTION
记事本 h1 在 preview 下继承了右对齐属性，修正。
