### PR TITLE
修复API源码链接

### DIFF
--- a/app/views/home/api.html.erb
+++ b/app/views/home/api.html.erb
@@ -1,6 +1,6 @@
 <div class="box">
   <h1>Ruby China API 目录</h1>
-  <p>下面是简单的 API 路由列表, 具体请参加源代码 <a href="https://github.com/ruby-china/ruby-china/blob/master/lib/api.rb" target="_blank">api.rb</a></p>
+  <p>下面是简单的 API 路由列表, 具体请参加源代码 <a href="https://github.com/ruby-china/ruby-china/blob/master/app/grape/api.rb" target="_blank">api.rb</a></p>
   <table class="table">
     <thead>
       <tr>


### PR DESCRIPTION
API的源代码地址已经改变，然而[http://ruby-china.com/api](http://ruby-china.com/api)上的相应链接并未更新
