### PR TITLE
add a timestamp to avatar url

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -54,7 +54,8 @@ module UsersHelper
       img_src = "#{Setting.gravatar_proxy}/avatar/#{user.email_md5}.png?s=#{width * 2}&d=404"
       img = image_tag(img_src, :class => "uface", :style => "width:#{width}px;height:#{width}px;")
     else
-      img = image_tag(user.avatar.url(user_avatar_size_name_for_2x(size)), :class => "uface", :style => "width:#{width}px;height:#{width}px;")
+      avatar_url = "#{user.avatar.url(user_avatar_size_name_for_2x(size))}?#{user.updated_at.to_i}"
+      img = image_tag(avatar_url, :class => "uface", :style => "width:#{width}px;height:#{width}px;")
     end
 
     if link


### PR DESCRIPTION
今天看到社区一个帖子有网友说改了头像无法看到，需要强制刷新才可以显示。目前因社区数据库回档，该帖子已找不到。

看了一下，ruby-china 会员头像文件名是固定的，这样的图片在某些 CDN（不了解又拍是否会缓存）和浏览器都会缓存。给头像的url加了个时间戳，解决浏览器缓存的问题，CDN 缓存需要更换文件名，这个牵扯到设计的变化，仅做建议参考，并未在此 Pull Request 内实现。

因没有具体记录能够体现会员修改图片的时间，所以取的是 user 的 updated_at， 故编辑其他信息不修改头像也会引起会员头像浏览器缓存失效。
###### 

On branch add_querystring_to_avatar
Changes to be committed:
modified:   app/helpers/users_helper.rb
