### PR TITLE
add 'favorited' and 'liked' fields to topic api

### DIFF
--- a/app/grape/api_v2.rb
+++ b/app/grape/api_v2.rb
@@ -22,7 +22,7 @@ module RubyChina
       #   /api/topics/index.json?page=1&per_page=15
       get do
         @topics = Topic.last_actived.includes(:user).paginate(:page => params[:page], :per_page => params[:per_page] || 30)
-        present @topics, :with => APIEntities::Topic
+        present @topics, :with => APIEntities::Topic, :current_user => current_user
       end
 
       # Get active topics of the specified node
@@ -35,7 +35,7 @@ module RubyChina
         @topics = @node.topics.last_actived
           .limit(page_size)
           .includes(:user)
-        present @topics, :with => APIEntities::Topic
+        present @topics, :with => APIEntities::Topic, :current_user => current_user
       end
 
       # Post a new topic

--- a/app/grape/entities.rb
+++ b/app/grape/entities.rb
@@ -42,6 +42,12 @@ module RubyChina
     
     class Topic < Grape::Entity
       expose :id, :title, :created_at, :updated_at, :replied_at, :replies_count, :node_name, :node_id, :last_reply_user_id, :last_reply_user_login
+      expose (:favorited){ |topic,options|
+        !!options[:current_user] &&  options[:current_user].favorite_topic_ids.include?(topic.id) 
+      }
+      expose (:liked){ |topic,options|
+        !!options[:current_user] &&  topic.liked_by_user?(options[:current_user])
+      }      
       expose :user, :using => APIEntities::User
     end
 


### PR DESCRIPTION
Adding these two fields makes it convenient for api-client to judge one
toppic is favorited or liked by current authenticated user.
