### PR TITLE
如果用户的邮箱不公开，那么在API里返回空字符串

### DIFF
--- a/app/grape/entities.rb
+++ b/app/grape/entities.rb
@@ -15,7 +15,11 @@ module RubyChina
     end
 
     class DetailUser < Grape::Entity
-      expose :id, :name, :login, :email, :location, :company, :twitter, :website, :bio, :tagline, :github_url
+      expose :id, :name, :login, :location, :company, :twitter, :website, :bio, :tagline, :github_url
+      expose :email do |model, opts|
+        model.email_public ? model.email : ''
+      end
+
       # deprecated: gravatar_hash, use avatar_url for user avatar
       expose(:gravatar_hash) { |model, opts| Digest::MD5.hexdigest(model.email || "") }
       expose(:avatar_url) do |model, opts|


### PR DESCRIPTION
目前API里返回了所有用户的邮箱。但对于“不公开的邮箱”的用户，应该返回 `null` 或者 空字符串。

另外：刚刚clone下来的代码有9个失败的测试用例。有几个模板相关的似乎和编码有关系，另外几个和帖子相关。
