### PR TITLE
Fix .editor_toolbar overflow in new topic page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ solr/pids/
 bin/
 tags
 chromedriver.log
+.ruby-version
+.ruby-gemset

--- a/app/assets/stylesheets/pages.scss
+++ b/app/assets/stylesheets/pages.scss
@@ -1,6 +1,6 @@
 #pages {
-  .tools { 
-    text-align:right; margin-bottom:10px; 
+  .tools {
+    text-align:right; margin-bottom:10px;
     a {
       margin-left:10px;
     }
@@ -33,6 +33,3 @@
   padding:4px;
   overflow: scroll;
 }
-
-.editor_toolbar{width:680px;} 
-


### PR DESCRIPTION
![screenshot from 2013-09-01 12 12 48](https://f.cloud.github.com/assets/2468952/1063455/d7269888-12bc-11e3-897b-e542dfd7144a.png)
Setting width of the editor toolbar will lead to the overflow of the toolbar control and the form action div.
