### PR TITLE
Issue #211 Fixed google search redirect to google home page if search string include '#'

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,6 +1,8 @@
 # coding: utf-8
 class SearchController < ApplicationController
   def index
-    redirect_to "https://www.google.com.hk/#hl=zh-CN&q=site:ruby-china.org+#{params[:q]}"
+    keywords = params[:q] || ""
+    keywords.gsub!("#", "%23")
+    redirect_to "https://www.google.com.hk/#hl=zh-CN&q=site:ruby-china.org+#{keywords}"
   end
 end


### PR DESCRIPTION
 Fixed google search request redirect to google home page if search string include '#' char.
