### PR TITLE
Add emojis list support with at.js

### DIFF
--- a/app/assets/javascripts/app.coffee
+++ b/app/assets/javascripts/app.coffee
@@ -99,6 +99,10 @@ window.App =
       data : logins
       search_key : "search"
       tpl : "<li data-value='${login}'>${login} <small>${name}</small></li>"
+    .atwho
+      at : ":"
+      data : window.EMOJI_LIST
+      tpl : "<li data-value='${name}:'><img src='http://l.ruby-china.org/assets/emojis/${name}.png' height='20' width='20'/> ${name} </li>"
     true
 
   initForDesktopView : () ->


### PR DESCRIPTION
`http://l.ruby-china.org/assets/emojis/${name}.png` 固定了 url 似乎不太好。

我找到了 `Settings.upload_url` 这个配置，但是如果想使用这个字段似乎要把 `app.coffee` 变更为 `app.coffee.erb` 然后使用 `window.UPLOAD_URL = "<%= Setting.upload_url %>"` 感觉变动太大了。
