### PR TITLE
为 api/v2/topics/:id.json 增加 include_deldeted 参数，使得 api/v2/topics/:id.json 可以返回所有回复，包括被删除的回复，回复的字段增加deleted_at，回复严格按照id排序

### DIFF
--- a/app/grape/api_v2.rb
+++ b/app/grape/api_v2.rb
@@ -56,12 +56,14 @@ module RubyChina
       end
 
       # Get topic detail
+      # params:
+      #   include_deleted(optional)
       # Example
       #   /api/topics/1.json
       get ":id" do
-        @topic = Topic.includes(:replies).find_by_id(params[:id])
+        @topic = Topic.find_by_id(params[:id])
         @topic.hits.incr(1)
-        present @topic, :with => APIEntities::DetailTopic
+        present @topic, :with => APIEntities::DetailTopic, :include_deleted => params[:include_deleted]
       end
 
       # Post a new reply

--- a/app/grape/entities.rb
+++ b/app/grape/entities.rb
@@ -40,7 +40,7 @@ module RubyChina
     end
 
     class Reply < Grape::Entity
-      expose :id, :body, :body_html, :created_at, :updated_at
+      expose :id, :body, :body_html, :created_at, :updated_at, :deleted_at
       expose :user, :using => APIEntities::User
     end
     
@@ -54,7 +54,11 @@ module RubyChina
       expose(:hits) { |topic| topic.hits.to_i }
       expose :user, :using => APIEntities::User
       # replies only exposed when a single topic is fetched
-      expose :replies, :using => APIEntities::Reply, :unless => { :collection => true }
+      expose(:replies, :unless => { :collection => true }) do |model, opts|
+        replies = model.replies
+        replies = replies.unscoped if opts[:include_deleted]
+        APIEntities::Reply.represent(replies.asc(:_id))
+      end
     end
 
     class Node < Grape::Entity


### PR DESCRIPTION
修复 http://ruby-china.org/topics/16419 #255 中提到的前两个问题
