### PR TITLE
纠正帖子（取消）关注，收藏的APIv2的返回值，现在格式统一成：操作成功返回true，操作失败返回false

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -102,11 +102,13 @@ class Topic
     return false if uid == self.user_id
     return false if self.follower_ids.include?(uid)
     self.push(follower_ids: uid)
+    true
   end
 
   def pull_follower(uid)
     return false if uid == self.user_id
     self.pull(follower_ids: uid)
+    true
   end
 
   def update_last_reply(reply)

--- a/spec/api/topics_spec.rb
+++ b/spec/api/topics_spec.rb
@@ -63,6 +63,7 @@ describe RubyChina::API, "topics" do
       t = Factory(:topic, :title => "new topic 2")
       post "/api/topics/#{t.id}/follow.json", :token => user.private_token
       response.status.should == 201      
+      response.body.should == 'true'
       t.reload.follower_ids.should include(user.id)
     end
   end
@@ -73,6 +74,7 @@ describe RubyChina::API, "topics" do
       t = Factory(:topic, :title => "new topic 2")
       post "/api/topics/#{t.id}/unfollow.json", :token => user.private_token
       response.status.should == 201      
+      response.body.should == 'true'
       t.reload.follower_ids.should_not include(user.id)
     end
   end
@@ -83,6 +85,7 @@ describe RubyChina::API, "topics" do
       t = Factory(:topic, :title => "new topic 3")
       post "/api/topics/#{t.id}/favorite.json", :token => user.private_token
       response.status.should == 201      
+      response.body.should == 'true'
       user.reload.favorite_topic_ids.should include(t.id)
     end
   end
@@ -93,6 +96,7 @@ describe RubyChina::API, "topics" do
       t = Factory(:topic, :title => "new topic 3")
       post "/api/topics/#{t.id}/favorite.json", :token => user.private_token, :type => 'unfavorite'
       response.status.should == 201      
+      response.body.should == 'true'
       user.reload.favorite_topic_ids.should_not include(t.id)
     end
   end  


### PR DESCRIPTION
修复 http://ruby-china.org/topics/16419 #255 中提到的第三个问题
