### PR TITLE
fixed api cors 使用rack-cors，解决跨域问题  #233

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,8 @@ gem 'eventmachine', '1.0.3'
 gem "puma", "2.6.0"
 # Faye Server 需要
 gem 'thin', "1.5.0"
+# for api 跨域
+gem 'rack-cors', require: 'rack/cors'
 
 group :development, :test do
   gem 'capistrano', '2.9.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,6 +269,7 @@ GEM
     quiet_assets (1.0.2)
       railties (>= 3.1, < 5.0)
     rack (1.5.2)
+    rack-cors (0.2.9)
     rack-mount (0.8.3)
       rack (>= 1.0.0)
     rack-test (0.6.2)
@@ -431,6 +432,7 @@ DEPENDENCIES
   postmark-rails (= 0.4.1)
   puma (= 2.6.0)
   quiet_assets (~> 1.0.2)
+  rack-cors
   rails (= 4.0.2)
   rails-i18n (= 0.1.8)
   rails_autolink (>= 1.1.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,8 +45,14 @@ module RubyChina
     }
     
     config.assets.precompile += %w(application.css app.js topics.css topics.js window.css front.css cpanel.css
-        users.css pages.css pages.js notes.css notes.js 
-        mobile.css home.css)
+      users.css pages.css pages.js notes.css notes.js 
+      mobile.css home.css)
+    config.middleware.use Rack::Cors do
+      allow do
+        origins '*'
+        resource '/*', headers: :any, methods: [:get, :post, :put, :delete, :destroy]
+      end
+    end
   end
 end
 


### PR DESCRIPTION
使用rack-cors，解决跨域问题，实际中也是这样用，不过application.rb里配置的路由还需要更严谨

```
config.middleware.use Rack::Cors do
      allow do
        origins '*'
        resource '/*', headers: :any, methods: [:get, :post, :put, :delete, :destroy]
      end
    end
```
