### PR TITLE
增加消息中心的API的GET和DELETE接口 fixes #262

### DIFF
--- a/app/grape/api_v2.rb
+++ b/app/grape/api_v2.rb
@@ -178,6 +178,45 @@ module RubyChina
       end
     end
 
+    resources :notifications do
+      # Get notifications of current user, this API won't mark notifications as read
+      # require authentication
+      # params[:page]
+      # params[:per_page]: default is 20
+      # Example
+      #   /api/notifications.json?page=1&per_page=20
+      get do
+        authenticate!
+        @notifications = current_user.notifications.recent.paginate :page => params[:page], :per_page => params[:per_page] || 20
+        present @notifications, :with => APIEntities::Notification
+      end
+
+      # Delete all notifications of current user
+      # require authentication
+      # params:
+      #   NO
+      # Example
+      #   DELETE /api/notifications.json
+      delete do
+        authenticate!
+        current_user.notifications.delete_all
+        true
+      end
+
+      # Delete all notifications of current user
+      # require authentication
+      # params:
+      #   id
+      # Example
+      #   DELETE /api/notifications/1.json
+      delete ":id" do
+        authenticate!
+        @notification = current_user.notifications.find params[:id]
+        @notification.destroy
+        true
+      end
+    end
+
     # List all cool sites
     # Example
     # GET /api/sites.json

--- a/app/grape/entities.rb
+++ b/app/grape/entities.rb
@@ -65,5 +65,16 @@ module RubyChina
       expose :id, :name, :topics_count, :summary, :section_id, :sort
       expose(:section_name) {|model, opts| model.section.try(:name) }
     end
+
+    class Notification < Grape::Entity
+      expose :id, :created_at, :updated_at, :read
+      expose(:mention, :if => lambda {|model, opts| model.is_a? ::Notification::Mention }) do |model, opts|
+        # mode.mentionable_type could be "Reply" or "Topic"
+        APIEntities.const_get(model.mentionable_type).represent model.mentionable
+      end
+      expose(:reply, :if => lambda {|model, opts| model.is_a? ::Notification::TopicReply }) do |model, opts|
+        APIEntities::Reply.represent model.reply
+      end
+    end
   end
 end

--- a/spec/api/notifications_spec.rb
+++ b/spec/api/notifications_spec.rb
@@ -1,0 +1,141 @@
+require 'spec_helper'
+
+describe RubyChina::API, "notifications" do
+  let(:user) { Factory(:user) }
+
+  before(:each) do
+    user.update_private_token
+  end
+
+  describe "GET /api/notifications.json" do
+    it "must require token" do
+      get "/api/v2/notifications.json"
+      response.status.should == 401
+    end
+
+    it "should be ok" do
+      get "/api/v2/notifications.json", :token => user.private_token
+      response.status.should == 200
+    end
+
+    it "should get notification for a mention in a reply" do
+      topic = Factory :topic, :user => user
+      reply = Factory :reply, :topic => topic, :user => user, :body => "Test to mention user"
+      mention = Factory :notification_mention, :user => user, :mentionable => reply
+      get "/api/v2/notifications.json", :token => user.private_token
+      response.status.should == 200
+      json = JSON.parse(response.body)
+      json[0]["read"].should be_false
+      json[0]["mention"]["body"].should == "Test to mention user"
+      json[0]["mention"]["user"]["login"].should == user.login
+    end
+
+    it "should get notification for a reply" do
+      topic = Factory :topic, :user => user
+      reply = Factory :reply, :topic => topic, :user => user, :body => "Test to reply user"
+      notification = Factory :notification_topic_reply, :user => user, :reply => reply
+      get "/api/v2/notifications.json", :token => user.private_token
+      response.status.should == 200
+      json = JSON.parse(response.body)
+      json[0]["read"].should be_false
+      json[0]["reply"]["body"].should == "Test to reply user"
+      json[0]["reply"]["user"]["login"].should == user.login
+    end
+
+    it "should get notification for a mention in a topic" do
+      node = Factory :node
+      topic = Factory :topic, :user => user, :node => node, :title => "Test to mention user in a topic"
+      mention = Factory :notification_mention, :user => user, :mentionable => topic
+      get "/api/v2/notifications.json", :token => user.private_token
+      response.status.should == 200
+      json = JSON.parse(response.body)
+      json[0]["read"].should be_false
+      json[0]["mention"]["title"].should == "Test to mention user in a topic"
+      json[0]["mention"]["node_name"].should == node.name
+      json[0]["mention"]["user"]["login"].should == user.login
+    end
+
+    it "should return a list of notifications of the current user" do
+      topic = Factory :topic, :user => user
+      replies = (0...10).map {|i| Factory :reply, :topic => topic, :user => user, :body => "Test to mention user #{i}" }
+      mentions = (0...10).map {|i| Factory :notification_mention, :user => user, :mentionable => replies[i] }
+
+      get "/api/v2/notifications.json", :token => user.private_token
+      response.status.should == 200
+      json = JSON.parse(response.body)
+      json.should have(10).items
+      json.each_with_index {|item, i| item["mention"]["body"] == replies[i].body }
+
+      get "/api/v2/notifications.json", :token => user.private_token, :per_page => 5
+      response.status.should == 200
+      json = JSON.parse(response.body)
+      json.should have(5).items
+      json.each_with_index {|item, i| item["mention"]["body"] == replies[i].body }
+
+      get "/api/v2/notifications.json", :token => user.private_token, :per_page => 5, :page => 2
+      response.status.should == 200
+      json = JSON.parse(response.body)
+      json.should have(5).items
+      json.each_with_index {|item, i| item["mention"]["body"] == replies[i + 5].body }
+    end
+  end
+
+  describe "DELETE /api/notifications.json" do
+    it "must require token" do
+      delete "/api/v2/notifications.json"
+      response.status.should == 401
+    end
+
+    it "should delete all notifications of current user" do
+      topic = Factory :topic, :user => user
+      replies = (0...10).map {|i| Factory :reply, :topic => topic, :user => user, :body => "Test to mention user #{i}" }
+      mentions = (0...10).map {|i| Factory :notification_mention, :user => user, :mentionable => replies[i] }
+
+      get "/api/v2/notifications.json", :token => user.private_token
+      response.status.should == 200
+      json = JSON.parse(response.body)
+      json.should have(10).items
+
+      delete "/api/v2/notifications.json", :token => user.private_token
+      response.status.should == 200
+      response.body.should == 'true'
+
+      get "/api/v2/notifications.json", :token => user.private_token
+      response.status.should == 200
+      json = JSON.parse(response.body)
+      json.should be_empty
+    end
+  end
+
+  describe "DELETE /api/notifications/:id.json" do
+    it "must require token" do
+      delete "/api/v2/notifications/1.json"
+      response.status.should == 401
+    end
+
+    it "should delete the specified notification of current user" do
+      topic = Factory :topic, :user => user
+      replies = (0...10).map {|i| Factory :reply, :topic => topic, :user => user, :body => "Test to mention user #{i}" }
+      mentions = (0...10).map {|i| Factory :notification_mention, :user => user, :mentionable => replies[i] }
+
+      get "/api/v2/notifications.json", :token => user.private_token
+      response.status.should == 200
+      json = JSON.parse(response.body)
+      json.should have(10).items
+
+      deleted_ids = mentions.map(&:id).select(&:odd?)
+
+      deleted_ids.each do |i|
+        delete "/api/v2/notifications/#{i}.json", :token => user.private_token
+        response.status.should == 200
+        response.body.should == 'true'
+      end
+
+      get "/api/v2/notifications.json", :token => user.private_token
+      response.status.should == 200
+      json = JSON.parse(response.body)
+      json.should have(10 - deleted_ids.size).items
+      json.map {|item| deleted_ids.should_not include(item["id"]) }
+    end
+  end
+end


### PR DESCRIPTION
现在可以通过GET /api/v2/notifications.json 获取当前用户所有的提醒
也可以通过DELETE /api/v2/notificaitons.json 删除当前用户所有的提醒
或是通过 DELETE /api/v2/notifications/:id.json 删除当前用户某一个提醒
