### PR TITLE
修复消息中心返回的数据没有topic_id的问题, fixes #267

### DIFF
--- a/app/grape/entities.rb
+++ b/app/grape/entities.rb
@@ -40,7 +40,7 @@ module RubyChina
     end
 
     class Reply < Grape::Entity
-      expose :id, :body, :body_html, :created_at, :updated_at, :deleted_at
+      expose :id, :body, :body_html, :created_at, :updated_at, :deleted_at, :topic_id
       expose :user, :using => APIEntities::User
     end
     

--- a/spec/api/notifications_spec.rb
+++ b/spec/api/notifications_spec.rb
@@ -27,6 +27,7 @@ describe RubyChina::API, "notifications" do
       json = JSON.parse(response.body)
       json[0]["read"].should be_false
       json[0]["mention"]["body"].should == "Test to mention user"
+      json[0]["mention"]["topic_id"].should == topic.id
       json[0]["mention"]["user"]["login"].should == user.login
     end
 
@@ -39,6 +40,7 @@ describe RubyChina::API, "notifications" do
       json = JSON.parse(response.body)
       json[0]["read"].should be_false
       json[0]["reply"]["body"].should == "Test to reply user"
+      json[0]["reply"]["topic_id"].should == topic.id
       json[0]["reply"]["user"]["login"].should == user.login
     end
 


### PR DESCRIPTION
这个问题将导致无法通过一个Notification引用的Reply来找到所属的Topic
