### PR TITLE
为markdown链接增加target属性,从新窗口打开.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,8 @@ module RubyChina
       g.fixture_replacement :factory_girl, :dir => "spec/factories"
     end
 
+    config.action_view.sanitized_allowed_attributes = %w{target}
+
     config.to_prepare {
       Devise::Mailer.layout "mailer"
     }

--- a/lib/markdown.rb
+++ b/lib/markdown.rb
@@ -12,10 +12,11 @@ module Redcarpet
       include Rouge::Plugins::Redcarpet
 
       def initialize(extensions={})
-        super(extensions.merge(:xhtml => true,
-                               :no_styles => true,
-                               :escape_html => true,
-                               :hard_wrap => true))
+        super(extensions.merge(xhtml: true,
+                               no_styles: true,
+                               escape_html: true,
+                               hard_wrap: true,
+                               link_attributes: {target: '_blank'}))
       end
 
       
@@ -71,9 +72,9 @@ class MarkdownConverter
   private
   def initialize
     @converter = Redcarpet::Markdown.new(Redcarpet::Render::HTMLwithSyntaxHighlight.new, {
-        :autolink => true,
-        :fenced_code_blocks => true,
-        :no_intra_emphasis => true
+        autolink: true,
+        fenced_code_blocks: true,
+        no_intra_emphasis: true
       })
   end
 end
@@ -235,12 +236,12 @@ class MarkdownTopicConverter < MarkdownConverter
 
   def initialize
     @converter = Redcarpet::Markdown.new(Redcarpet::Render::HTMLwithTopic.new, {
-        :autolink => true,
-        :fenced_code_blocks => true,
-        :strikethrough => true,
-        :space_after_headers => true,
-        :disable_indented_code_blocks => true,
-        :no_intra_emphasis => true
+        autolink: true,
+        fenced_code_blocks: true,
+        strikethrough: true,
+        space_after_headers: true,
+        disable_indented_code_blocks: true,
+        no_intra_emphasis: true
       })
     @emoji = MdEmoji::Render.new
   end


### PR DESCRIPTION
现在是当前页面打开,想看刚才的内容,总是需要返回,有时候会忘记了.
