### PR TITLE
Remove animation when upload gif image

### DIFF
--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -16,6 +16,18 @@ class AvatarUploader < BaseUploader
     process :resize_to_fill => [120, 120]
   end
 
+  # Remove the animation when upload gif image
+  process :remove_animation
+
+  def remove_animation
+    manipulate! do |img|
+      if img.mime_type.match /gif/
+        img.collapse!
+      end
+      img
+    end
+  end
+
   def filename
     if super.present?
       "avatar/#{model.id}.#{file.extension.downcase}"


### PR DESCRIPTION
上传带动画的gif时候，如果在carrierwave中有resize会报错
添加一个progress，上传gif的时候去除动画
参考于[Carrierwave + MiniMagick - How to squash animated GIFs to their first frame?](http://stackoverflow.com/questions/13480499/carrierwave-minimagick-how-to-squash-animated-gifs-to-their-first-frame)
