### PR TITLE
update notification count when read

### DIFF
--- a/app/assets/javascripts/app.coffee
+++ b/app/assets/javascripts/app.coffee
@@ -35,7 +35,7 @@ window.App =
   faye_server_url : ''
   asset_url : ''
   root_url : ''
-  
+
   isLogined : ->
     App.current_user_id != null
 
@@ -66,7 +66,7 @@ window.App =
     if !App.isLogined()
       location.href = "/account/sign_in"
       return false
-      
+
     $el = $(el)
     likeable_type = $el.data("type")
     likeable_id = $el.data("id")
@@ -141,7 +141,7 @@ window.App =
     faye = new Faye.Client(App.faye_server_url)
     notification_subscription = faye.subscribe "/notifications_count/#{App.access_token}",(json) ->
       span = $("#user_notifications_count span")
-      new_title = $(document).attr("title").replace(/\(\d+\) /,'')
+      new_title = $(document).attr("title").replace(/^\(\d+\) /,'')
       if json.count > 0
         span.addClass("badge-error")
         new_title = "(#{json.count}) #{new_title}"

--- a/app/models/notification/base.rb
+++ b/app/models/notification/base.rb
@@ -12,9 +12,10 @@ class Notification::Base
   index :user_id => 1, :read => 1
 
   scope :unread, -> { where(:read => false) }
-  
+
   after_create :realtime_push_to_client
-  
+  after_update :realtime_push_to_client
+
   def realtime_push_to_client
     if self.user
       hash = self.notify_hash
@@ -22,7 +23,7 @@ class Notification::Base
       FayeClient.send("/notifications_count/#{self.user.temp_access_token}", hash)
     end
   end
-  
+
   def content_path
     ""
   end

--- a/setup.rb
+++ b/setup.rb
@@ -77,7 +77,7 @@ end
 
 # Config files
 puts_section "Configure" do
-  %w(config mongoid redis thin).each do |fname|
+  %w(config mongoid redis thin secrets).each do |fname|
     `cp config/#{fname}.yml.default config/#{fname}.yml`
   end
 


### PR DESCRIPTION
问题描述：

当开多个 tab 在浏览 ruby-china 时，如果有新的通知，这时会实时在页面上订阅显示。
可当阅读完这些通知时，旧的页面顶部通知栏并没有随着更新。

PS：

在本地跑个 ruby-china 有点波折啊。比如 config/secrets.yml 是后来 rails 升级后才有的，可能作者们的 local 机器有，但是 setup.rb 里面没有，我就加进去了。
