### PR TITLE
Fix #306: disable force_ssl for grape APIs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,11 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
   helper_method :unread_notify_count
 
+  # We put force_ssl here instead of in the config files
+  # because this would not influence the grape APIs.
+  # cf. issue #306
+  force_ssl if Rails.env.production?
+
   before_filter do
     resource = controller_name.singularize.to_sym
     method = "#{resource}_params"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,6 +65,4 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   # config.active_record.dump_schema_after_migration = false
-
-  config.force_ssl = true
 end


### PR DESCRIPTION
- Put force_ssl in ApplicationController instead of in the config files
  because this would not influence the grape APIs.
