### PR TITLE
Fix #320

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,8 +19,6 @@ class User
   field :email_public, type: Mongoid::Boolean
   field :encrypted_password, type: String, default: ""
 
-  validates_presence_of :email
-
   ## Recoverable
   field :reset_password_token,   type: String
   field :reset_password_sent_at, type: Time


### PR DESCRIPTION
Same validation logic on email could be found
at Line 29 to 31 of `Devise::Models::Validatable`.

Therefore `validates_presence_of :email`
in application code is not necessary.
