### PR TITLE
hot topic function

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,8 @@ gem 'thin', '1.5.0'
 gem 'rack-cors', require: 'rack/cors'
 gem 'rack-utf8_sanitizer'
 
+gem 'whenever', :require => false
+
 group :development, :test do
   gem 'capistrano', '2.9.0', require: false
   gem 'rvm-capistrano', require: false
@@ -109,6 +111,7 @@ group :development, :test do
   gem 'capybara', '~> 2.3.0'
   gem 'api_taster', '0.6.0'
   gem 'letter_opener'
+  gem 'pry'
 
   # 用于组合小图片
   gem 'sprite-factory', '1.4.1', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,9 @@ GEM
       railties (>= 3.0)
     celluloid (0.15.2)
       timers (~> 1.1.0)
+    chronic (0.10.2)
     chunky_png (1.2.8)
+    coderay (1.1.0)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     coffee-rails (4.0.1)
@@ -193,6 +195,7 @@ GEM
     md_emoji (1.0.2)
       railties (>= 3.1.0)
       redcarpet (>= 2.0)
+    method_source (0.8.2)
     mime-types (1.25.1)
     mini_magick (3.7.0)
       subexec (~> 0.2.1)
@@ -252,6 +255,10 @@ GEM
       actionmailer
       postmark (>= 0.9.0)
       rake
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     puma (2.6.0)
       rack (>= 1.1, < 2.0)
     quiet_assets (1.0.2)
@@ -340,6 +347,7 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
+    slop (3.6.0)
     social-share-button (0.1.5)
     sprite-factory (1.4.1)
     sprockets (2.11.0)
@@ -378,6 +386,9 @@ GEM
     warden (1.2.3)
       rack (>= 1.0)
     websocket-driver (0.3.2)
+    whenever (0.9.2)
+      activesupport (>= 2.3.4)
+      chronic (>= 0.6.3)
     will_paginate (3.0.4)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -429,6 +440,7 @@ DEPENDENCIES
   omniauth-github (~> 1.1.0)
   postmark (= 0.9.15)
   postmark-rails (= 0.4.1)
+  pry
   puma (= 2.6.0)
   quiet_assets (~> 1.0.2)
   rack-cors
@@ -453,4 +465,5 @@ DEPENDENCIES
   thin (= 1.5.0)
   turbolinks (~> 2.2.2)
   uglifier (>= 1.3.0)
+  whenever
   will_paginate (= 3.0.4)

--- a/app/cells/topics/sidebar_daily_hot.html.erb
+++ b/app/cells/topics/sidebar_daily_hot.html.erb
@@ -1,0 +1,8 @@
+<div class="totals box">
+  <h2 class="title"><%= t("common.daily_hot")%></h2>
+  <ul>
+    <% @topics.each do |topic| %>
+      <li><%= link_to topic.title, topic %></li>
+    <% end %>
+  </ul>
+</div>

--- a/app/cells/topics/sidebar_weekly_hot.html.erb
+++ b/app/cells/topics/sidebar_weekly_hot.html.erb
@@ -1,0 +1,8 @@
+<div class="totals box">
+  <h2 class="title"><%= t("common.weekly_hot")%></h2>
+  <ul>
+    <% @topics.each do |topic| %>
+      <li><%= link_to topic.title, topic %></li>
+    <% end %>
+  </ul>
+</div>

--- a/app/cells/topics_cell.rb
+++ b/app/cells/topics_cell.rb
@@ -20,6 +20,20 @@ class TopicsCell < BaseCell
     render
   end
 
+  # 每日热门
+  cache :sidebar_daily_hot, expires_in: 10.minutes
+  def sidebar_daily_hot
+    @topics = Topic.daily_hot_topics
+    render
+  end
+
+  # 每周热门
+  cache :sidebar_weekly_hot, expires_in: 1.hour
+  def sidebar_weekly_hot
+    @topics = Topic.weekly_hot_topics
+    render
+  end
+
   # 节点下面的最新话题
   cache :sidebar_for_node_recent_topics, expires_in: 30.minutes do |cell, args|
     ['node', args[:topic].node_id].join("-")

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -60,8 +60,9 @@ class TopicsController < ApplicationController
   end
 
   def show
-    @topic = Topic.without_body.find(params[:id])
+    @topic = Topic.find(params[:id])
     @topic.hits.incr(1)
+    @topic.update_score
     @node = @topic.node
     @show_raw = params[:raw] == '1'
 
@@ -72,18 +73,18 @@ class TopicsController < ApplicationController
 
     @replies = @topic.replies.unscoped.without_body.asc(:_id)
     @replies = @replies.paginate(page: @page, per_page: @per_page)
-    
+
     check_current_user_status_for_topic
     set_special_node_active_menu
-    
+
     set_seo_meta "#{@topic.title} &raquo; #{t("menu.topics")}"
 
     fresh_when(etag: [@topic, @has_followed, @has_favorited, @replies, @node, @show_raw])
   end
-  
+
   def check_current_user_status_for_topic
     return false if not current_user
-    
+
     # 找出用户 like 过的 Reply，给 JS 处理 like 功能的状态
     @user_liked_reply_ids = []
     @replies.each { |r| @user_liked_reply_ids << r.id if r.liked_user_ids.index(current_user.id) != nil }
@@ -94,7 +95,7 @@ class TopicsController < ApplicationController
     # 是否收藏
     @has_favorited = current_user.favorite_topic_ids.index(@topic.id) == nil
   end
-  
+
   def set_special_node_active_menu
     case @node.try(:id)
     when Node.jobs_id
@@ -171,7 +172,7 @@ class TopicsController < ApplicationController
     current_user.favorite_topic(params[:id])
     render text: '1'
   end
-  
+
   def unfavorite
     current_user.unfavorite_topic(params[:id])
     render text: '1'

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -57,6 +57,31 @@ class Topic
 
   counter :hits, default: 0
 
+  HOURS_IN_DAY = 24
+  UPDATES_IN_HOUR = 6
+  DAYS_IN_WEEK = 7
+  UPDATES_IN_DAY = 24
+  REPLY_WEIGHT = 3
+
+  counter :count_in_hour, default: 0
+  value :daily_hits_hour_ago, default: 0
+  value :daily_score_hour_ago, default: 0
+  list :daily_hits, maxlength: (HOURS_IN_DAY - 1)
+  value :daily_replies_hour_ago, default: 0
+  list :daily_replies, maxlength: (HOURS_IN_DAY - 1)
+
+  counter :count_in_day, default: 0
+  value :weekly_hits_day_ago, default: 0
+  value :weekly_score_day_ago, default: 0
+  list :weekly_hits, maxlength: (DAYS_IN_WEEK - 1)
+  value :weekly_replies_day_ago, default: 0
+  list :weekly_replies, maxlength: (DAYS_IN_WEEK - 1)
+
+  field :daily_score, type: Integer, default: 0
+  field :weekly_score, type: Integer, default: 0
+  index weekly_score: -1
+  index daily_score: -1
+
   delegate :login, to: :user, prefix: true, allow_nil: true
   delegate :body, to: :last_reply, prefix: true, allow_nil: true
 
@@ -71,6 +96,9 @@ class Topic
   scope :popular, -> { where(:likes_count.gt => 5) }
   scope :without_node_ids, Proc.new { |ids| where(:node_id.nin => ids) }
   scope :excellent, -> { where(:excellent.gte => 1) }
+  # 热门话题
+  scope :daily_hot_topics, -> { desc(:daily_score).limit(100) }
+  scope :weekly_hot_topics, -> { desc(:weekly_score).limit(100) }
 
   def self.find_by_message_id(message_id)
     where(message_id: message_id).first
@@ -115,7 +143,7 @@ class Topic
   def update_last_reply(reply, opts = {})
     # replied_at 用于最新回复的排序，如果帖着创建时间在一个月以前，就不再往前面顶了
     return false if reply.blank? && !opts[:force]
-    
+
     self.last_active_mark = Time.now.to_i if self.created_at > 1.month.ago
     self.replied_at = reply.try(:created_at)
     self.last_reply_id = reply.try(:id)
@@ -123,12 +151,12 @@ class Topic
     self.last_reply_user_login = reply.try(:user_login)
     self.save
   end
-  
+
   # 更新最后更新人，当最后个回帖删除的时候
   def update_deleted_last_reply(deleted_reply)
     return false if deleted_reply.blank?
     return false if self.last_reply_user_id != deleted_reply.user_id
-    
+
     previous_reply = self.replies.where(:_id.nin => [deleted_reply.id]).recent.first
     self.update_last_reply(previous_reply, force: true)
   end
@@ -160,4 +188,96 @@ class Topic
   def excellent?
     self.excellent >= 1
   end
+
+  def self.update_daily_hot_topics
+    Topic.daily_hot_topics.each { |topic| topic.update_daily_hot_topics }
+  end
+
+  def self.update_weekly_hot_topics
+    Topic.weekly_hot_topics.each { |topic| topic.update_weekly_hot_topics }
+  end
+
+  def update_daily_score
+    self.daily_score, hits_in_hour, replies_in_hour = calc_score(
+      daily_hits_hour_ago.value.to_i,
+      daily_replies_hour_ago.value.to_i,
+      daily_score_hour_ago.value.to_i,
+      HOURS_IN_DAY, REPLY_WEIGHT
+    )
+    [hits_in_hour, replies_in_hour]
+  end
+
+  def update_weekly_score
+    self.weekly_score, hits_in_day, replies_in_day = calc_score(
+      weekly_hits_day_ago.value.to_i,
+      weekly_replies_day_ago.value.to_i,
+      weekly_score_day_ago.value.to_i,
+      DAYS_IN_WEEK, REPLY_WEIGHT
+    )
+    [hits_in_day, replies_in_day]
+  end
+
+  def update_score
+    update_daily_score
+    update_weekly_score
+    save!
+  end
+
+  # 更新每日热门话题
+  def update_daily_hot_topics
+    # 计算当前时间段查看数，回复数
+    hits_in_hour, replies_in_hour = update_daily_score
+    if count_in_hour.value == UPDATES_IN_HOUR - 1 #整一个小时
+      # 储存每小时的查看数，回复数
+      self.daily_hits.unshift(hits_in_hour)
+      self.daily_replies.unshift(replies_in_hour)
+      # 计算分数
+      self.daily_score_hour_ago = calc_old_score(daily_hits, daily_replies, HOURS_IN_DAY-1, REPLY_WEIGHT)
+      # 储存总查看数，回复数
+      self.daily_hits_hour_ago.value = hits.value
+      self.daily_replies_hour_ago.value = replies_count
+      # 计数器清零
+      self.count_in_hour.reset
+    else
+      self.count_in_hour.incr(1)
+    end
+    # require 'pry'; binding.pry
+    save!
+  end
+
+  # 更新每周热门话题
+  def update_weekly_hot_topics
+    # 计算当前时间段查看数，回复数
+    hits_in_day, replies_in_day = update_weekly_score
+    if count_in_day.value == UPDATES_IN_DAY - 1 # 整一周
+      # 储存每小时的查看数，回复数
+      self.weekly_hits.unshift(hits_in_day)
+      self.weekly_replies.unshift(replies_in_day)
+      # 计算分数
+      self.weekly_score_day_ago = calc_old_score(weekly_hits, weekly_replies, DAYS_IN_WEEK-1, REPLY_WEIGHT)
+      # 储存总查看数，回复数
+      self.weekly_hits_day_ago.value = hits.value
+      self.weekly_replies_day_ago.value = replies_count
+      # 计数器清零
+      self.count_in_day.reset
+    else
+      self.count_in_day.incr(1)
+    end
+    save!
+  end
+
+  # 计算分数
+  def calc_score(old_hits, old_replies, old_score, length, weight)
+    hits_diff = hits.value - old_hits
+    replies_diff = replies_count - old_replies
+    score = (hits_diff + replies_diff*weight)*length + old_score
+    [score, hits_diff, replies_diff]
+  end
+
+  def calc_old_score(list0, list1, length, weight)
+    score = list0.each.with_index.inject(0) { |sum, (el, index)| sum + el.to_i*(length-index) }
+    score += weight*list1.each.with_index.inject(0) { |sum, (el, index)| sum + el.to_i*(length-index) }
+    score
+  end
+
 end

--- a/app/views/topics/_sidebar_for_topic_index.html.erb
+++ b/app/views/topics/_sidebar_for_topic_index.html.erb
@@ -3,3 +3,5 @@
 <%= render_cell :topics, :tips %>
 <%= raw SiteConfig.topic_index_sidebar_html %>
 <%= render_cell :topics, :sidebar_statistics %>
+<%= render_cell :topics, :sidebar_daily_hot %>
+<%= render_cell :topics, :sidebar_weekly_hot %>

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,6 +3,7 @@ require "bundler/capistrano"
 require "sidekiq/capistrano"
 require "rvm/capistrano"
 require 'puma/capistrano'
+require 'whenever/capistrano'
 
 default_run_options[:pty] = true
 

--- a/config/locales/menu.en.yml
+++ b/config/locales/menu.en.yml
@@ -59,6 +59,8 @@
     by: "by"
     at: "on"
     hot_topics: "Hot topics"
+    daily_hot: "Daily hot topics"
+    weekly_hot: "Weekly hot topics"
   reply:
     edit_reply: "Edit Reply"
     delete_reply_success: 'Delete successfully.'

--- a/config/locales/menu.zh-CN.yml
+++ b/config/locales/menu.zh-CN.yml
@@ -59,6 +59,8 @@
     by: "由"
     at: "在"
     hot_topics: "热门讨论"
+    daily_hot: "每日热门"
+    weekly_hot: "每周热门"
     hot_locations: "热门城市"
     replies_count: "回复"
     likes_count: 喜欢

--- a/config/locales/menu.zh-TW.yml
+++ b/config/locales/menu.zh-TW.yml
@@ -59,6 +59,8 @@
     by: "由"
     at: "在"
     hot_topics: "熱門討論"
+    daily_hot: "每日熱門"
+    weekly_hot: "每周熱門"
     hot_locations: "熱門城市"
   reply:
     edit_reply: "修改回應"
@@ -98,4 +100,3 @@
     recent_topics_title: "%{name}社區"
     recent_node_topics_description: "%{name} 社區 %{node_name} 節點最新討論。"
     recent_node_topics_title: "%{name} 社區 %{node_name} 節點"
-

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,18 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+every 1.hours do
+  runner "Topic.update_daily_hot_topics"
+end
+
+every 7.days do
+  runner "Topic.update_weekly_hot_topics"
+end
+
+# Learn more: http://github.com/javan/whenever


### PR DESCRIPTION
思路：
用whenever计时
以每日热门为例，每十分钟更新，按照算法计算一次分数，每更新6次（即为1小时），将这个小时的查看数和回复数（即当前查看回复数和储存的一小时前的查看回复数的差）移入 List ，并将当前总查看数和总回复数储存，这样 List 里面存有一天即 24 个小时的每小时查看回复数，用于计算分数。这个做法，避免了储存动则数百次的查看时间。
普通的更新方法采用每次 whenever 的更新任务即将所有 topics 更新一遍，在 topics 多的时候会有 performance 问题，于是采用每次查看即更新该 topic 分数，whenever 更新任务只更新在热门榜单上的 topics，这种做法有待讨论。
