### PR TITLE
when update reply, last_reply_usr_id should not be change

### DIFF
--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -37,13 +37,11 @@ class Reply
     end
   end
 
-  after_create :update_parent_topic
+  after_save :update_parent_topic
   def update_parent_topic
     topic.update_last_reply(self)
   end
 
-  # 更新的时候也更新话题的 updated_at 以便于清理缓存之类的东西
-  after_update :update_parent_topic_updated_at
   # 删除的时候也要更新 Topic 的 updated_at 以便清理缓存
   after_destroy :update_parent_topic_updated_at
   def update_parent_topic_updated_at
@@ -52,8 +50,8 @@ class Reply
       true
     end
   end
-  
-  
+
+
 
   after_create do
     Reply.delay.send_topic_reply_notification(self.id)

--- a/spec/controllers/replies_controller_spec.rb
+++ b/spec/controllers/replies_controller_spec.rb
@@ -14,7 +14,20 @@ describe RepliesController, :type => :controller do
       expect(user.topic_read?(topic)).to be_truthy
     end
   end
-  
+
+  describe "#update" do
+
+    let(:topic) { Factory :topic }
+    let(:user) { Factory :user }
+    let(:reply) { Factory :reply, :user => user, :topic => topic }
+
+    it "should not change topic's last reply info to previous one" do
+      sign_in user
+      post :update, topic_id: topic.id, id: reply.id, :reply => {:body => 'content'}, format: :js
+      expect(topic.reload.last_reply_user_login).to eq user.login
+    end
+  end
+
   describe "#destroy" do
     let(:topic) { Factory :topic }
     let(:admin) { Factory :admin }
@@ -22,29 +35,29 @@ describe RepliesController, :type => :controller do
     let(:user1) { Factory :user }
     let(:reply) { Factory :reply, :user => user, :topic => topic }
     let(:reply1) { Factory :reply, :user => user1, :topic => topic }
-    
+
     it "should require login to destroy reply" do
       delete :destroy, :topic_id => topic.id, :id => reply.id
       expect(response).not_to be_success
     end
-    
+
     it "user1 should not allow destroy reply" do
       sign_in user1
       delete :destroy, :topic_id => topic.id, :id => reply.id
       expect(response).not_to be_success
     end
-      
+
     it "user should destroy reply with itself" do
       sign_in user
       delete :destroy, :topic_id => topic.id, :id => reply.id
       expect(response).to redirect_to(topic_path(topic))
     end
-    
+
     it "admin should destroy reply" do
       sign_in admin
       delete :destroy, :topic_id => topic.id, :id => reply.id
       expect(response).to redirect_to(topic_path(topic))
-      
+
       delete :destroy, :topic_id => topic.id, :id => reply1.id
       expect(response).to redirect_to(topic_path(topic))
     end


### PR DESCRIPTION
当更新回帖而不是删除回帖的时候，topic 的 last_reply 的 info 不应该用上一回帖的 info。如 ruby china "RSL 寻优秀前端 / Ruby on Rails 工程师“ 一贴。 最后回复应该是 rsl 而不是 tomlive 。
