### PR TITLE
Add url_protocol to config.yml

### DIFF
--- a/config/config.yml.default
+++ b/config/config.yml.default
@@ -2,6 +2,7 @@ defaults: &defaults
   app_name: "Ruby China"
   foot_html: "&copy; Ruby China."
   domain: "127.0.0.1:3000"
+  url_protocol: 'http'
   admin_emails:
     - "admin@admin.com"
   google_analytics_key: ""

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false
   # config.action_mailer.delivery_method = :letter_opener
-  config.action_mailer.default_url_options = { :host => Setting.domain }
+  config.action_mailer.default_url_options = { host: Setting.domain, protocol: Setting.url_protocol }
   config.action_mailer.delivery_method   = :postmark
   config.action_mailer.postmark_settings = { :api_key => Setting.email_password }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options = { host: Setting.domain }
+  config.action_mailer.default_url_options = { host: Setting.domain, protocol: Setting.url_protocol }
   config.action_mailer.delivery_method   = :postmark
   config.action_mailer.postmark_settings = { api_key: Setting.email_password }
 


### PR DESCRIPTION
修复 reset password email中的url问题，因为 RubyChina 全站启用 https，所以需要添加一个 protocol 参数到 ActionMailer 的 default_url_options 中
