### PR TITLE
修复点击回复提醒后回复数为空的问题

### DIFF
--- a/app/views/replies/_create_callback.js.erb
+++ b/app/views/replies/_create_callback.js.erb
@@ -5,8 +5,8 @@ if($("#replies").length == 0){
     var current_floor = parseInt($("#replies").data("last-floor")) + 1;
     var dom = $('<%= j(render("reply", reply: reply, reply_counter: @topic.replies_count - 1, display_edit: true)) %>');
     $("#replies .items").append(dom);
-    $("#replies .total b").text('<%= @replies_count %>');
-    $('#topic-sidebar .total b').text('<%= @replies_count %>');
+    $("#replies .total b").text('<%= @topic.replies_count %>');
+    $('#topic-sidebar .total b').text('<%= @topic.replies_count %>');
     dom.find(".reply-floor").text(current_floor + " 楼");
     dom.find("a.edit").css("display", "inline-block");
     dom.addClass('light');


### PR DESCRIPTION
修复话题出现新回复后，点击新回复提示后 sidebar 的回复数为空的问题。

具体问题描述请查看： https://testerhome.com/topics/6489