### PR TITLE
Add application/json header in rspec api helper

### DIFF
--- a/spec/support/api_v3_support.rb
+++ b/spec/support/api_v3_support.rb
@@ -16,7 +16,9 @@ module APIV3Support
     end
 
     def default_headers
-      @default_headers ||= {}
+      # Providing JSON data, default `application/x-www-form-urlencoded`
+      # https://www.relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec#providing-json-data
+      @default_headers ||= { 'CONTENT_TYPE" => "application/json' }
     end
 
     def default_parameters
@@ -30,12 +32,19 @@ module APIV3Support
           # override empty params and headers with default
           parameters = combine_parameters(parameters, default_parameters)
           headers = combine_parameters(headers, default_headers)
+          if [:post, :put, :delete].include?(__callee__)
+            parameters = jsonify(parameters)
+          end
           super(path, params: parameters, headers: headers)
         end
       EOV
     end
 
     private
+
+    def jsonify(parameters)
+      JSON.dump(parameters)
+    end
 
     def combine_parameters(argument, default)
       # if both of them are hashes combine them

--- a/spec/support/api_v3_support.rb
+++ b/spec/support/api_v3_support.rb
@@ -18,7 +18,7 @@ module APIV3Support
     def default_headers
       # Providing JSON data, default `application/x-www-form-urlencoded`
       # https://www.relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec#providing-json-data
-      @default_headers ||= { 'CONTENT_TYPE" => "application/json' }
+      @default_headers ||= { 'CONTENT_TYPE' => 'application/json' }
     end
 
     def default_parameters


### PR DESCRIPTION
根据 request spec 的文档，请求时 content_type 需要显示指定为 `application/json` 发送的数据才是 json 格式，否则默认为 `application/x-www-form-urlencoded`

参考

- https://www.relishapp.com/rspec/rspec-rails/docs/request-specs/request-spec#providing-json-data