### PR TITLE
实现 Single sign-on 并同时支持用 SSO 登录或作为 SSO Provider.

### DIFF
--- a/app/controllers/auth/sso_controller.rb
+++ b/app/controllers/auth/sso_controller.rb
@@ -1,0 +1,76 @@
+module Auth
+  class SSOController < ApplicationController
+    def show
+      return render_404 if !Setting.sso_enabled?
+
+      destination_url = cookies.delete(:destination_url)
+      return_path = params[:return_path] || root_path
+
+      if destination_url && return_path == root_path
+        uri = URI::parse(destination_url)
+        return_path = "#{uri.path}#{uri.query ? "?" << uri.query : ""}"
+      end
+
+      sso = Homeland::SSO.generate_sso(return_path)
+      Rails.logger.warn("Verbose SSO log: Started SSO process\n\n#{sso.diagnostics}")
+      redirect_to sso.to_url
+    end
+
+    def login
+      return render_404 if !Setting.sso_enabled?
+
+      sso = Homeland::SSO.parse(request.query_string)
+      if !sso.nonce_valid?
+        return render(text: I18n.t("sso.timeout_expired"), status: 419)
+      end
+
+      return_path = sso.return_path
+      sso.expire_nonce!
+
+      begin
+        user = sso.find_or_create_user(request)
+      rescue => e
+        message = sso.diagnostics
+        message << "\n\n" << "-" * 100 << "\n\n"
+        message << e.message
+        message << "\n\n" << "-" * 100 << "\n\n"
+        message << e.backtrace.join("\n")
+
+        puts message
+
+        ExceptionLog.create(title: "SSO Failed to create or lookup user:", body: message)
+        render text: I18n.t("sso.unknown_error"), status: 500
+        return
+      end
+
+      if !user
+        render text: I18n.t("sso.not_found"), status: 500
+        return
+      end
+
+      redirect_to return_path
+    end
+
+    def provider
+      return render_404 if !Setting.sso_provider_enabled?
+
+      payload ||= request.query_string
+
+      if !current_user
+        store_location
+        redirect_to new_session_path(:user)
+        return
+      end
+
+      sso = SingleSignOn.parse(payload, Setting.sso['secret'])
+      sso.name = current_user.name
+      sso.username = current_user.login
+      sso.email = current_user.email
+      sso.bio = current_user.bio
+      sso.external_id = current_user.id.to_s
+      sso.admin = current_user.admin?
+
+      redirect_to sso.to_url(sso.return_sso_url)
+    end
+  end
+end

--- a/app/controllers/auth/sso_controller.rb
+++ b/app/controllers/auth/sso_controller.rb
@@ -69,6 +69,7 @@ module Auth
       sso.bio = current_user.bio
       sso.external_id = current_user.id.to_s
       sso.admin = current_user.admin?
+      sso.avatar_url = current_user.avatar.url(:lg)
 
       redirect_to sso.to_url(sso.return_sso_url)
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,6 @@ class SessionsController < Devise::SessionsController
 
   def new
     super
-    cache_referrer
   end
 
   def create
@@ -11,20 +10,12 @@ class SessionsController < Devise::SessionsController
     set_flash_message(:notice, :signed_in) if is_navigational_format?
     sign_in(resource_name, resource)
     respond_to do |format|
-      format.html { redirect_to topics_url }
+      format.html { redirect_back_or_default(root_url) }
       format.json { render status: '201', json: resource.as_json(only: [:login, :email]) }
     end
   end
 
   private
-
-  def cache_referrer
-    referrer = request.referrer
-    # Ignore other site url and user sign in url.
-    if referrer && referrer.include?(domain_or_host) && referrer.exclude?(new_user_session_path)
-      session['user_return_to'] = request.referrer
-    end
-  end
 
   # If not bind to a domain, request.domain is nil.
   def domain_or_host

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -34,7 +34,7 @@ class Setting < RailsSettings::Base
       self.https == true ? 'https' : 'http'
     end
 
-    def host
+    def base_url
       [self.protocol, self.domain].join("://")
     end
 
@@ -51,6 +51,15 @@ class Setting < RailsSettings::Base
     def has_profile_field?(name)
       return true if self.profile_fields.blank? || self.profile_fields == 'all'
       self.profile_fields.split(SEPARATOR_REGEXP).include?(name.to_s)
+    end
+
+    def sso_enabled?
+      return false if self.sso_provider_enabled?
+      self.sso['enable'] == true
+    end
+
+    def sso_provider_enabled?
+      self.sso['enable_provider'] == true
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,7 @@ class User < ApplicationRecord
   has_many :devices
   has_many :team_users
   has_many :teams, through: :team_users
+  has_one :sso, class_name: 'UserSSO', dependent: :destroy
 
   attr_accessor :password_confirmation
 
@@ -226,7 +227,7 @@ class User < ApplicationRecord
   def letter_avatar_url(size)
     path = LetterAvatar.generate(self.login, size).sub('public/', '/')
 
-    "#{Setting.protocol}://#{Setting.domain}#{path}"
+    "#{Setting.base_url}#{path}"
   end
 
   def large_avatar_url

--- a/app/models/user/omniauth_callbacks.rb
+++ b/app/models/user/omniauth_callbacks.rb
@@ -34,8 +34,7 @@ class User
             end
 
           user.name = data['name']
-          user.login = data['nickname']
-          user.login.gsub!(/[^\w]/, '_')
+          user.login = Homeland::Username.sanitize(data['nickname'])
           if provider == 'github'
             user.github = data['nickname']
           end

--- a/app/models/user_sso.rb
+++ b/app/models/user_sso.rb
@@ -1,0 +1,3 @@
+class UserSSO < ActiveRecord::Base
+  belongs_to :user
+end

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -1,7 +1,7 @@
 <%= simple_form_for @page do |f| %>
   <%= render "shared/error_messages", target: @page %>
 
-  <%= f.input :slug, hint: "http://#{Setting.domain}/wiki/:slug"%>
+  <%= f.input :slug, hint: "#{Setting.base_url}/wiki/:slug"%>
   <%= f.input :title, input_html: { class: "xxlarge" } %>
 
   <div class="edit-tools">

--- a/config/config.yml.default
+++ b/config/config.yml.default
@@ -69,6 +69,11 @@ defaults: &defaults
     password: ''
     authentication: 'plain'
     enable_starttls_auto: true
+  sso:
+    enable: false
+    enable_provider: false
+    url: ''
+    secret: ''
   github_token: "91726ee4170d8e2679ec"
   github_secret: "13c7e55e8e53c57a399181e96ea3a55a3fdd9c7c"
   apns_pem: ""

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   # config.action_cable.mount_path = nil
   # config.action_cable.url = 'wss://example.com/cable'
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
-  config.action_cable.allowed_request_origins = [Setting.host]
+  config.action_cable.allowed_request_origins = [Setting.base_url]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = Setting.https

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -11,6 +11,7 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  # user_sso -> UserSSO
+  inflect.acronym 'SSO'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,16 @@ Rails.application.routes.draw do
     omniauth_callbacks: 'users/omniauth_callbacks'
   }
 
+  # SSO
+  namespace :auth do
+    resource :sso, controller: 'sso' do
+      collection do
+        get :login
+        get :provider
+      end
+    end
+  end
+
   delete 'account/auth/:provider/unbind', to: 'users#auth_unbind', as: 'unbind_account'
 
   mount RuCaptcha::Engine, at: '/rucaptcha'

--- a/db/migrate/20161221022846_create_user_sso.rb
+++ b/db/migrate/20161221022846_create_user_sso.rb
@@ -1,0 +1,16 @@
+class CreateUserSSO < ActiveRecord::Migration[5.0]
+  def change
+    create_table :user_ssos do |t|
+      t.integer :user_id, null: false
+      t.string :uid, null: false, length: 255
+      t.string :username
+      t.string :email
+      t.string :name
+      t.string :avatar_url
+      t.text :last_payload, null: false
+      t.timestamps
+    end
+
+    add_index :user_ssos, :uid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161215014636) do
+ActiveRecord::Schema.define(version: 20161221022846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,6 +61,12 @@ ActiveRecord::Schema.define(version: 20161215014636) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["name"], name: "index_locations_on_name", using: :btree
+  end
+
+  create_table "monkeys", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "new_notifications", force: :cascade do |t|
@@ -256,6 +262,14 @@ ActiveRecord::Schema.define(version: 20161215014636) do
     t.index ["user_id"], name: "index_team_users_on_user_id", using: :btree
   end
 
+  create_table "test_documents", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "mentioned_user_ids", default: [],              array: true
+    t.text     "body"
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
+  end
+
   create_table "topics", force: :cascade do |t|
     t.integer  "user_id",                               null: false
     t.integer  "node_id",                               null: false
@@ -290,6 +304,19 @@ ActiveRecord::Schema.define(version: 20161215014636) do
     t.index ["suggested_at"], name: "index_topics_on_suggested_at", using: :btree
     t.index ["team_id"], name: "index_topics_on_team_id", using: :btree
     t.index ["user_id"], name: "index_topics_on_user_id", using: :btree
+  end
+
+  create_table "user_ssos", force: :cascade do |t|
+    t.integer  "user_id",      null: false
+    t.string   "uid",          null: false
+    t.string   "username"
+    t.string   "email"
+    t.string   "name"
+    t.string   "avatar_url"
+    t.text     "last_payload", null: false
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.index ["uid"], name: "index_user_ssos_on_uid", unique: true, using: :btree
   end
 
   create_table "users", force: :cascade do |t|
@@ -344,4 +371,13 @@ ActiveRecord::Schema.define(version: 20161215014636) do
     t.index ["login"], name: "index_users_on_login", using: :btree
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true, using: :btree
   end
+
+  create_table "walking_deads", force: :cascade do |t|
+    t.string   "name"
+    t.string   "tag"
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
 end

--- a/lib/homeland/sso.rb
+++ b/lib/homeland/sso.rb
@@ -1,0 +1,108 @@
+module Homeland
+  class SSO < SingleSignOn
+    def self.sso_url
+      Setting.sso['url']
+    end
+
+    def self.sso_secret
+      Setting.sso['secret']
+    end
+
+    def self.generate_sso(return_path="/")
+      sso = new
+      sso.nonce = SecureRandom.hex
+      sso.register_nonce(return_path)
+      sso.return_sso_url = Setting.base_url + "/account/sso_login"
+      sso
+    end
+
+    def self.generate_url(return_path="/")
+      generate_sso(return_path).to_url
+    end
+
+    def register_nonce(return_path)
+      if nonce
+        $redis.setex(nonce_key, NONCE_EXPIRY_TIME, return_path)
+      end
+    end
+
+    def nonce_valid?
+      nonce && $redis.get(nonce_key).present?
+    end
+
+    def return_path
+      $redis.get(nonce_key) || "/"
+    end
+
+    def expire_nonce!
+      if nonce
+        $redis.del nonce_key
+      end
+    end
+
+    def nonce_key
+      "SSO_NONCE_#{nonce}"
+    end
+
+    def find_or_create_user(request = nil)
+      sso_record = UserSSO.find_by(uid: external_id)
+
+      if sso_record && (user = sso_record.user)
+        sso_record.last_payload = unsigned_payload
+      else
+        user = match_email_or_create_user
+        sso_record = user.sso
+      end
+
+      # if the user isn't new or it's attached to the SSO record we might be overriding username or email
+      user.email = email if user.email.blank?
+      user.login = username if user.login.blank?
+      user.name = name if user.name.blank?
+      user.bio = bio if user.bio.blank?
+
+      # change external attributes for sso record
+      sso_record.username = username
+      sso_record.email = email
+      sso_record.name = name
+      sso_record.avatar_url = avatar_url
+
+      user.save!
+      user.update_tracked_fields!(request)
+
+      # Add as admin
+      if !admin.nil?
+        Setting.admin_emails = Setting.admin_emails + "\n" + email
+      end
+
+      sso_record.save!
+      sso_record && sso_record.user
+    end
+
+    def match_email_or_create_user
+      user = User.find_by_email(email)
+      if !user
+        user_params = {
+          email: email,
+          name: name,
+          login: Homeland::Username.sanitize(username || name),
+          password: Devise.friendly_token[0, 20]
+        }
+
+        user = User.create!(user_params)
+      end
+
+      sso_record = user.sso || user.create_sso(
+        last_payload: unsigned_payload,
+        uid: external_id,
+        username: username,
+        email: email,
+        name: name,
+        avatar_url: avatar_url
+      )
+
+      sso_record.last_payload = unsigned_payload
+      sso_record.uid = external_id
+      user
+    end
+  end
+end

--- a/lib/homeland/username.rb
+++ b/lib/homeland/username.rb
@@ -1,0 +1,7 @@
+module Homeland
+  class Username
+    def self.sanitize(username)
+      username.gsub(/[^\w.-]/, '_')
+    end
+  end
+end

--- a/lib/single_sign_on.rb
+++ b/lib/single_sign_on.rb
@@ -1,0 +1,106 @@
+# From: https://github.com/discourse/discourse/blob/master/lib/single_sign_on.rb
+class SingleSignOn
+  ACCESSORS         = [:nonce, :name, :username, :email, :avatar_url, :bio, :external_id, :return_sso_url, :admin]
+  FIXNUMS           = []
+  BOOLS             = [:admin]
+  NONCE_EXPIRY_TIME = 10.minutes
+
+  attr_accessor(*ACCESSORS)
+  attr_accessor :sso_secret, :sso_url
+
+  def self.sso_secret
+    raise RuntimeError, "sso_secret not implemented on class, be sure to set it on instance"
+  end
+
+  def self.sso_url
+    raise RuntimeError, "sso_url not implemented on class, be sure to set it on instance"
+  end
+
+  def self.parse(payload, sso_secret = nil)
+    sso = new
+    sso.sso_secret = sso_secret if sso_secret
+
+    parsed = Rack::Utils.parse_query(payload)
+    if sso.sign(parsed["sso"]) != parsed["sig"]
+      diags = "\n\nsso: #{parsed["sso"]}\n\nsig: #{parsed["sig"]}\n\nexpected sig: #{sso.sign(parsed["sso"])}"
+      if parsed["sso"] =~ /[^a-zA-Z0-9=\r\n\/+]/m
+        raise RuntimeError, "The SSO field should be Base64 encoded, using only A-Z, a-z, 0-9, +, /, and = characters. Your input contains characters we don't understand as Base64, see http://en.wikipedia.org/wiki/Base64 #{diags}"
+      else
+        raise RuntimeError, "Bad signature for payload #{diags}"
+      end
+    end
+
+    decoded = Base64.decode64(parsed["sso"])
+    decoded_hash = Rack::Utils.parse_query(decoded)
+
+    ACCESSORS.each do |k|
+      val = decoded_hash[k.to_s]
+      val = val.to_i if FIXNUMS.include? k
+      if BOOLS.include? k
+        val = ["true", "false"].include?(val) ? val == "true" : nil
+      end
+      sso.send("#{k}=", val)
+    end
+
+    decoded_hash.each do |k,v|
+      # 1234567
+      # custom.
+      #
+      if k[0..6] == "custom."
+        field = k[7..-1]
+        sso.custom_fields[field] = v
+      end
+    end
+
+    sso
+  end
+
+  def diagnostics
+    SingleSignOn::ACCESSORS.map do |a|
+      "#{a}: #{send(a)}"
+    end.join("\n")
+  end
+
+  def sso_secret
+    @sso_secret || self.class.sso_secret
+  end
+
+  def sso_url
+    @sso_url || self.class.sso_url
+  end
+
+  def custom_fields
+    @custom_fields ||= {}
+  end
+
+  def sign(payload)
+    OpenSSL::HMAC.hexdigest("sha256", sso_secret, payload)
+  end
+
+  def to_url(base_url=nil)
+    base = "#{base_url || sso_url}"
+    "#{base}#{base.include?('?') ? '&' : '?'}#{payload}"
+  end
+
+  def payload
+    payload = Base64.encode64(unsigned_payload)
+    "sso=#{CGI::escape(payload)}&sig=#{sign(payload)}"
+  end
+
+  def unsigned_payload
+    payload = {}
+    ACCESSORS.each do |k|
+     next if (val = send k) == nil
+
+     payload[k] = val
+    end
+
+    if @custom_fields
+      @custom_fields.each do |k,v|
+        payload["custom.#{k}"] = v.to_s
+      end
+    end
+
+    Rack::Utils.build_query(payload)
+  end
+end

--- a/spec/controllers/auth/sso_controller_spec.rb
+++ b/spec/controllers/auth/sso_controller_spec.rb
@@ -132,6 +132,7 @@ describe Auth::SSOController, type: :controller do
       expect(sso2.username).to eq(user.login)
       expect(sso2.external_id).to eq(user.id.to_s)
       expect(sso2.bio).to eq(user.bio)
+      expect(sso2.avatar_url).not_to eq(nil)
       expect(sso2.admin).to eq(true)
     end
 

--- a/spec/controllers/auth/sso_controller_spec.rb
+++ b/spec/controllers/auth/sso_controller_spec.rb
@@ -1,0 +1,146 @@
+require 'rails_helper'
+
+describe Auth::SSOController, type: :controller do
+  let(:sso_secret) { 'foo(*&@!12q36)' }
+
+  describe 'GET /auth/sso/login' do
+    let(:mock_ip) { '11.22.33.44' }
+    before do
+      @sso_url = "http://somesite.com/homeland-sso"
+
+      request.host = Setting.domain
+
+      allow(Setting).to receive(:sso).and_return({
+        'enable' => true,
+        'url'    => @sso_url,
+        'secret' => sso_secret,
+      })
+      allow(Setting).to receive(:sso_enabled?).and_return(true)
+      allow_any_instance_of(ActionDispatch::Request).to receive(:remote_ip).and_return(mock_ip)
+    end
+
+    def get_sso(return_path)
+      nonce = SecureRandom.hex
+      dso = Homeland::SSO.new
+      dso.nonce = nonce
+      dso.register_nonce(return_path)
+
+      sso = SingleSignOn.new
+      sso.nonce = nonce
+      sso.sso_secret = sso_secret
+      sso
+    end
+
+    it 'can take over an account' do
+      user_template = build(:user)
+      sso = get_sso('/topics/123')
+      sso.email = user_template.email
+      sso.external_id = 'abc123'
+      sso.name = 'Test SSO User'
+      sso.username = 'test-sso-user'
+      sso.bio = 'This is a bio text'
+      sso.avatar_url = 'http://foobar.com/avatar/1.jpg'
+
+      get :login, params: Rack::Utils.parse_query(sso.payload)
+
+      expect(response).to redirect_to('/topics/123')
+      user = User.find_by_email(sso.email)
+      expect(user.new_record?).to eq(false)
+      expect(user.login).to eq(sso.username)
+      expect(user.name).to eq(sso.name)
+      expect(user.bio).to eq(sso.bio)
+      expect(user.sso).not_to eq(nil)
+      expect(user.sso.uid).to eq(sso.external_id)
+      expect(user.sso.username).to eq(sso.username)
+      expect(user.sso.name).to eq(sso.name)
+      expect(user.sso.email).to eq(sso.email)
+      expect(user.sso.avatar_url).to eq(sso.avatar_url)
+      expect(user.current_sign_in_ip).to eq(mock_ip)
+      expect(user.current_sign_in_at).not_to eq(nil)
+    end
+
+    it 'can sign a exist user' do
+      user = create(:user, name: nil, bio: nil)
+      user.create_sso({ uid: 'abc1237161', last_payload: '' })
+
+      sso = get_sso('/')
+      sso.email = user.email
+      sso.external_id = user.sso.uid
+      sso.name = 'Test SSO User'
+      sso.username = 'test-sso-user'
+      sso.bio = 'This is a bio text'
+      sso.avatar_url = 'http://foobar.com/avatar/1.jpg'
+
+      expect do
+        get :login, params: Rack::Utils.parse_query(sso.payload)
+      end.to change(User, :count).by(0)
+
+      expect(response).to redirect_to('/')
+      user1 = User.find_by_id(user.id)
+      expect(user1.name).to eq(sso.name)
+      expect(user1.login).to eq(user.login)
+      expect(user1.bio).to eq(sso.bio)
+    end
+
+    it 'can take an admin account' do
+      user_template = build(:user)
+      sso = get_sso('/hello/world')
+      sso.email = user_template.email
+      sso.external_id = 'abc123'
+      sso.name = 'Test SSO User'
+      sso.username = user_template.login
+      sso.admin = true
+
+      get :login, params: Rack::Utils.parse_query(sso.payload)
+      expect(response).to redirect_to('/hello/world')
+      user = User.find_by_email(sso.email)
+      expect(user.admin?).to eq(true)
+      expect(Setting.has_admin?(sso.email)).to eq(true)
+    end
+  end
+
+  describe 'GET /auth/sso/provider' do
+    let(:user) { create(:user) }
+
+    before do
+      allow(Setting).to receive(:sso).and_return({
+        'secret' => sso_secret,
+      })
+      allow(Setting).to receive(:sso_provider_enabled?).and_return(true)
+
+      @sso = SingleSignOn.new
+      @sso.nonce = "mynonce"
+      @sso.sso_secret = sso_secret
+      @sso.return_sso_url = 'http://foobar.com/sso/callback'
+    end
+
+    it "should work" do
+      sign_in user
+      allow(Setting).to receive(:has_admin?).with(user.email).and_return(true)
+      get :provider, params: Rack::Utils.parse_query(@sso.payload)
+      expect(response.status).to eq(302)
+
+      location = response.location
+      # javascript code will handle redirection of user to return_sso_url
+      expect(location).to match(/^http:\/\/foobar.com\/sso\/callback/)
+
+      payload = location.split("?")[1]
+      sso2 = SingleSignOn.parse(payload, @sso.sso_secret)
+
+      expect(sso2.email).to eq(user.email)
+      expect(sso2.name).to eq(user.name)
+      expect(sso2.username).to eq(user.login)
+      expect(sso2.external_id).to eq(user.id.to_s)
+      expect(sso2.bio).to eq(user.bio)
+      expect(sso2.admin).to eq(true)
+    end
+
+    it 'should work with sign in' do
+      get :provider, params: Rack::Utils.parse_query(@sso.payload)
+      expect(response).to redirect_to('/account/sign_in')
+
+      expect(session[:return_to]).to match('/auth/sso/provider')
+      expect(session[:return_to]).to eq(request.url)
+    end
+  end
+end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -10,24 +10,10 @@ describe SessionsController, type: :controller do
 
     context 'cache referrer' do
       it "should store referrer if it's from self site" do
-        referrer = "#{request.base_url}/account/edit"
-        request.env['HTTP_REFERER'] = referrer
+        session['return_to'] = "/account/edit?id=123"
+        old_return_to = session['return_to']
         get :new
-        expect(session['user_return_to']).to eq referrer
-      end
-
-      it "should skip referrer if it's from other site" do
-        referrer = "http://#{SecureRandom.hex(4)}.com"
-        request.env['HTTP_REFERER'] = referrer
-        get :new
-        expect(session['user_return_to']).to eq nil
-      end
-
-      it 'should skip referrer if it is user sign in page' do
-        referrer = "#{request.base_url}/account/sign_in"
-        request.env['HTTP_REFERER'] = referrer
-        get :new
-        expect(session['user_return_to']).to eq nil
+        expect(session['return_to']).to eq(old_return_to)
       end
     end
   end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -13,7 +13,7 @@ describe Setting, type: :model do
     it 'should work' do
       allow(Setting).to receive(:domain).and_return("homeland.io")
       allow(Setting).to receive(:https).and_return(true)
-      expect(Setting.host).to eq "https://homeland.io"
+      expect(Setting.base_url).to eq "https://homeland.io"
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -538,7 +538,7 @@ describe User, type: :model do
   describe '.letter_avatar_url' do
     let(:user) { create(:user) }
     it 'should work' do
-      expect(user.letter_avatar_url(240)).to include("#{Setting.protocol}://#{Setting.domain}/system/letter_avatars/")
+      expect(user.letter_avatar_url(240)).to include("#{Setting.base_url}/system/letter_avatars/")
     end
   end
 


### PR DESCRIPTION
- 可以支持三方应用提供的 SSO 途径来登录；
- 可以作为 SSO 提供者，为三方应用提供 SSO 登录功能；
- 改进登录后 return_to 的实现细节.

## TODO

- [x] 编写接入文档；