### PR TITLE
refactor: add action column in reply api

### DIFF
--- a/app/views/api/v3/application/_reply.json.jbuilder
+++ b/app/views/api/v3/application/_reply.json.jbuilder
@@ -20,7 +20,7 @@
 if reply
   json.cache! ["v1", reply, defined?(detail)] do
     json.(reply, :id, :body_html, :topic_id, :created_at, :updated_at,
-                 :likes_count)
+                 :likes_count, :action)
     json.deleted reply.deleted_at.present?
     json.user do
       json.partial! 'user', user: reply.user


### PR DESCRIPTION
reply api的返回的json中没有action，这样无法判断一些系统级的回复(关闭话题、加精)。