### PR TITLE
rucaptcha_image_tag with aliyun CDN lead aliyun host url

### DIFF
--- a/app/views/account/create.js.erb
+++ b/app/views/account/create.js.erb
@@ -4,5 +4,5 @@
 <% else %>
   $('#new_user .alert').remove();
   $('#new_user').prepend('<%= j render("shared/error_messages", target: resource) %>');
-  $('.rucaptcha-image-box').html('<%= j rucaptcha_image_tag %>');
+  $('.rucaptcha-image-box').html('<img class="rucaptcha-image" src="<%= ru_captcha.root_path -%>" alt="Rucaptcha">');
 <% end %>

--- a/app/views/account/new.html.erb
+++ b/app/views/account/new.html.erb
@@ -29,7 +29,7 @@
         <div class="form-group">
           <div class="input-group">
             <%= rucaptcha_input_tag(class: 'form-control input-lg', placeholder: t('common.captcha')) %>
-            <span class="input-group-addon input-group-captcha"><a class="rucaptcha-image-box" href="#"><%= rucaptcha_image_tag %></a></span>
+            <span class="input-group-addon input-group-captcha"><a class="rucaptcha-image-box" href="#"><img class="rucaptcha-image" src="<%= ru_captcha.root_path -%>" alt="Rucaptcha"></a></span>
           </div>
         </div>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -14,7 +14,7 @@
         <div class="form-group">
           <div class="input-group">
             <%= rucaptcha_input_tag(class: 'form-control input-lg', placeholder: t('common.captcha')) %>
-            <span class="input-group-addon input-group-captcha"><a class="rucaptcha-image-box" href="#"><%= rucaptcha_image_tag %></a></span>
+            <span class="input-group-addon input-group-captcha"><a class="rucaptcha-image-box" href="#"><img class="rucaptcha-image" src="<%= ru_captcha.root_path -%>" alt="Rucaptcha"></a></span>
           </div>
         </div>
 


### PR DESCRIPTION
发现直接使用rucaptcha_image_tag的话，由于阿里云的自动翻译，图片的src会变成https://bucket_name.oss-cn-shanghai.aliyuncs.com开头，这样就无法在页面显示了。