### PR TITLE
首页移动端样式调整

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -80,8 +80,6 @@ h2 {
   .topics {
     .topic {
       .title {
-        height: 30px;
-        overflow: hidden;
       }
     }
   }


### PR DESCRIPTION
首页移动端样式调整
首页移动端样式调整-标题不自动折行，超出部分隐藏了。

取消：
height: 30px;
overflow: hidden;