### PR TITLE
Bring back navbar and title for oauth pages

### DIFF
--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -1,6 +1,7 @@
 module Oauth
   class ApplicationsController < Doorkeeper::ApplicationsController
     before_action :authenticate_user!
+    helper_method :unread_notify_count
 
     def index
       @applications = current_user.oauth_applications
@@ -20,6 +21,11 @@ module Oauth
       else
         render :new
       end
+    end
+
+    def unread_notify_count
+      return 0 if current_user.blank?
+      @unread_notify_count ||= Notification.unread_count(current_user)
     end
   end
 end

--- a/app/views/layouts/simple.html.erb
+++ b/app/views/layouts/simple.html.erb
@@ -3,7 +3,7 @@
 <head>
   <meta charset='utf-8' />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
-  <title><%= yield(:title) || Setting.app_name %></title>
+  <title><%= content_for?(:title) ? yield(:title) : Setting.app_name %></title>
   <meta name="apple-mobile-web-app-capable" content="no">
   <meta content='True' name='HandheldFriendly' />
   <%= stylesheet_link_tag "front" %>
@@ -19,8 +19,10 @@
           <%= raw Setting.navbar_brand_html %>
         </div>
 
-        <div id="main-nav-menu">
+        <div class="collapse navbar-collapse" id="main-navbar-collapse">
+          <%= render "shared/navbar" %>
         </div>
+        <%= render "shared/usernav" %>
       </div>
     </nav>
   </div>


### PR DESCRIPTION
`layout/simple` was removed in this [commit](https://github.com/ruby-china/homeland/commit/a546c098bd242588e3397e79025af52ced122815), and added back in this [commit](https://github.com/ruby-china/homeland/commit/382c5c430b7171c68739bbbcc826791b60f639bd). But in the second commit, navbar and usernav are missing. So pages for "oauth/applications/*" would look like this:

![screen shot 2017-07-03 at 16 10 58](https://user-images.githubusercontent.com/531650/27810018-39c4e884-600a-11e7-9040-f23ab23cb289.png)

This PR will bring back navbar, usernav and the page title:

![screen shot 2017-07-03 at 16 11 51](https://user-images.githubusercontent.com/531650/27810027-59ca39c2-600a-11e7-8573-64b0ac74b0e5.png)

