### PR TITLE
重构 MentionTopic，并修正提及已关闭的话题无法提交的问题。

### DIFF
--- a/app/jobs/mention_topic_job.rb
+++ b/app/jobs/mention_topic_job.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# 在被提及的话题里面创建 mention 回复，连接到提及的话题
+class MentionTopicJob < ApplicationJob
+  queue_as :notifications
+
+  def perform(topic_ids, target_type:, target_id:, user_id:)
+    return if topic_ids.blank?
+
+    topics = Topic.where(id: topic_ids)
+
+    topics.each do |topic|
+      next if topic.replies.where(target_type: target_type, target_id: target_id).any?
+
+      reply_param = {
+        action: "mention",
+        body: "",
+        topic: topic,
+        target_type: target_type,
+        target_id: target_id,
+        user_id: user_id
+      }
+
+      Reply.create!(reply_param)
+    end
+  end
+end

--- a/app/models/concerns/mention_topic.rb
+++ b/app/models/concerns/mention_topic.rb
@@ -14,23 +14,15 @@ module MentionTopic
   def extract_mentioned_topic_ids
     matched_ids = body.scan(TOPIC_LINK_REGEXP).flatten
     current_topic_id = self.class.name == "Topic" ? self.id : self.topic_id
-    if matched_ids.any?
-      matched_ids = matched_ids.map(&:to_i).reject { |id| id == current_topic_id }
-      self.mentioned_topic_ids = Topic.where("id IN (?)", matched_ids).pluck(:id)
-    end
+    return if matched_ids.blank?
+    matched_ids = matched_ids.map(&:to_i).reject { |id| id == current_topic_id }
+    return Topic.where("id IN (?)", matched_ids).pluck(:id)
   end
 
   private
     def create_releated_for_mentioned_topics
-      extract_mentioned_topic_ids
-      return false if self.mentioned_topic_ids.blank?
-      Reply.transaction do
-        self.mentioned_topic_ids.each do |topic_id|
-          topic = Topic.find_by(id: topic_id)
-          next if topic.blank?
-          next if topic.replies.where(target: self).any?
-          Reply.create_system_event!(user: self.user, topic: topic, action: "mention", target: self)
-        end
-      end
+      topic_ids = extract_mentioned_topic_ids
+      return if topic_ids.blank?
+      MentionTopicJob.perform_later(topic_ids, target_type: self.class.name, target_id: self.id, user_id: self.user_id)
     end
 end

--- a/app/models/reply.rb
+++ b/app/models/reply.rb
@@ -20,12 +20,12 @@ class Reply < ApplicationRecord
   validates :body, uniqueness: { scope: %i[topic_id user_id], message: "不能重复提交。" }, unless: -> { system_event? }
   validate do
     ban_words = (Setting.ban_words_on_reply || "").split("\n").collect(&:strip)
-    if body.strip.downcase.in?(ban_words)
+    if body && body.strip.downcase.in?(ban_words)
       errors.add(:body, "请勿回复无意义的内容，如你想收藏或赞这篇帖子，请用帖子后面的功能。")
     end
 
     if topic&.closed?
-      errors.add(:topic, "已关闭，不再接受回帖或修改回帖。")
+      errors.add(:topic, "已关闭，不再接受回帖或修改回帖。") unless system_event?
     end
 
     if reply_to_id

--- a/lib/homeland/version.rb
+++ b/lib/homeland/version.rb
@@ -3,7 +3,7 @@
 module Homeland
   class << self
     def version
-      "3.1.0.beta2"
+      "3.1.0.beta3"
     end
   end
 end

--- a/spec/models/concerns/mention_topic_spec.rb
+++ b/spec/models/concerns/mention_topic_spec.rb
@@ -10,22 +10,26 @@ describe MentionTopic, type: :model do
     it "should extract mentioned user ids" do
       topic = Topic.new body: "://#{Setting.domain}/topics/#{topics[0].id} ://#{Setting.domain}/topics/456"
       expect(topic.extract_mentioned_topic_ids).to eq([topics[0].id])
-      expect(topic.mentioned_topic_ids).to eq([topics[0].id])
 
       reply = Reply.new body: "://#{Setting.domain}/topics/#{topics[0].id}
       ://#{Setting.domain}/topics/#{topics[1].id}
       ://#{Setting.domain}/topics/456"
       expect(reply.extract_mentioned_topic_ids).to include(topics[0].id, topics[1].id)
-      expect(reply.mentioned_topic_ids).to include(topics[0].id, topics[1].id)
     end
   end
 
   describe ".create_releated_for_mentioned_topics" do
     it "should topic work" do
       t = create :topic, body: "://#{Setting.domain}/topics/#{topics[0].id} ://#{Setting.domain}/topics/456"
-      expect(topics[0].replies.where(action: "mention", target: t).count).to eq 1
+      expect(topics[0].replies.where(action: "mention", target: t, user_id: t.user_id).count).to eq 1
 
       expect { t.save }.to change(Reply, :count).by(0)
+    end
+
+    it "should close topic work" do
+      closed_topic = create :topic, closed_at: Time.now
+      t = create :topic, body: "://#{Setting.domain}/topics/#{closed_topic.id}"
+      expect(closed_topic.replies.where(action: "mention", target: t).count).to eq 1
     end
 
     it "should reply work" do


### PR DESCRIPTION
并将 MentionTopic 的关联创建动作放 Queue 里面执行