### PR TITLE
招聘页新增一个 filter, 根据城市筛选帖子

### DIFF
--- a/app/assets/stylesheets/front.scss
+++ b/app/assets/stylesheets/front.scss
@@ -170,6 +170,17 @@
       }
     }
   }
+
+  .prefix-filter {
+    @extend .filter;
+    &>li {
+      margin-right: 40px;
+      &>a {
+        padding: 0px 0px;
+      }
+    }
+  }
+
 }
 
 .topics-node {

--- a/app/views/topics/_node_info.html.erb
+++ b/app/views/topics/_node_info.html.erb
@@ -7,7 +7,7 @@
           <span class="total">共有 <%= node.topics_count %> 个讨论主题</span>
           <div class="pull-right">
             <% if node.collapse_summary? %>
-            <a class="btn btn-default" data-toggle="collapse" href="#node-summary"><i class="fa fa-lightbulb-o"></i> 节点介绍</a>
+              <a class="btn btn-default" data-toggle="collapse" href="#node-summary"><i class="fa fa-lightbulb-o"></i> 节点介绍</a>
             <% end %>
             <%= block_node_tag(node) %>
           </div>
@@ -15,6 +15,16 @@
         <div class="summary<%= ' collapse' if node.collapse_summary? %>" id="node-summary">
           <%= sanitize_markdown node.summary_html %>
         </div>
+        <% if node.name == '招聘' %>
+          <ul class="nav nav-pills prefix-filter">
+            <hr>
+            <% cache "prefixes", expires_in: 7.days do %>
+              <% Location.hot.limit(12).each do |prefix| %>
+                <li><%= link_to prefix.name, homeland_jobs.jobs_path(location: prefix.name) %></li>
+              <% end %>
+            <% end %>
+          </ul>
+        <% end %>
       <% else %>
         <%= render 'node_selector' %>
         <ul class="filter nav nav-pills">


### PR DESCRIPTION
[关联PR](https://github.com/ruby-china/homeland-jobs/pull/2)

#### 实现：

在插件 Homeland::Jobs 中通过匹配~~热门城市列表和~~招聘板标题的 [城市] 前缀来进一步筛选 @topics 的 scope，在 招聘 栏目的节点信息下方添加一个迷你 filter 来进行城市的筛选。

选择热门城市列表的原因是考虑，在 Ruby China 上某座城市的求职 / 招聘帖的数量和此城市的注册用户数应该是正相关的。

~~路由方面参考了 ruby-china.org/users/city/北京 来进行处理。~~

#### 需求：

起因是自己在使用招聘版的时候一直感觉有些不便……当求职者在某个城市求职时，经常会有只想查看这座城市的招聘贴的情况。

##### p.s.

初学者中的初学者，如果哪里做的不好或不对还望能不吝赐教一下，万分感谢！