### PR TITLE
忽略storage文件夹

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ spec/examples.txt
 .vagrant
 .byebug_history
 .ruby-version
+/storage/*


### PR DESCRIPTION
Rails 5.2.0 版本后，需要忽略storage文件夹，因为Active Storage本地保存时，会创建一个storage文件夹。