### PR TITLE
Fixed DEPRECATION WARNING about deprecated sass @extend .a.b in application.scss

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -518,10 +518,6 @@ img.emoji { width:20px; height:20px; }
       display: inline-block;
       padding: 8px;
       margin: 0;
-
-      &.active {
-        @extend .btn-default.active;
-      }
     }
   }
 


### PR DESCRIPTION
And &.active { @extend .btn-default.active } is not need,
because it already extend .btn-default and will auto extend .btn-default.active

> DEPRECATION WARNING on line 524 of /home/xxxx/homeland/app/assets/stylesheets/application.scss:
Extending a compound selector, .btn-default.active, is deprecated and will not be supported in a future release.
Consider "@extend .btn-default, .active" instead.
See https://github.com/sass/sass/issues/1599 for details.

这个extend不需要声明了，前面已经extend .btn-default了，会自动extend .btn-default的.active,我在浏览器中前后对比了，发现删除这个，生成的css是没有变的，所以我的改动是可行的，并且消除了DEPRECATION WARNING