### PR TITLE
Fixed title_tag xss bug

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,7 +55,7 @@ module ApplicationHelper
   end
 
   def title_tag(str)
-    content_for :title, raw("#{str} · #{Setting.app_name}")
+    content_for :title, h("#{str} · #{Setting.app_name}")
   end
 
   MOBILE_USER_AGENTS = "palm|blackberry|nokia|phone|midp|mobi|symbian|chtml|ericsson|minimo|" \


### PR DESCRIPTION
Someone post a topic with special javascript code in topic title may have serious consequences.

Eg: Create a post with title:
    
    </title><script>alert ('我弹你一下');</script><title> 

Issue #956