### PR TITLE
修复 issue#1055 的分页 bug, 修复已屏蔽主题列表页和屏蔽操作的命名冲突 bug

### DIFF
--- a/app/controllers/topics/list_actions.rb
+++ b/app/controllers/topics/list_actions.rb
@@ -29,15 +29,16 @@ module Topics
       render_index("favorites")
     end
 
+    # GET /topics/last
     def last
       @topics = topics_scope.recent.page(params[:page])
       render_index("recent")
     end
 
-    # GET /topics/ban
-    def ban
+    # GET /topics/banned
+    def banned
       @topics = Topic.ban.recent.page(params[:page])
-      render_index("recent")
+      render_index("banned")
     end
 
     # GET /topics/excellent

--- a/app/views/topics/_node_info.html.erb
+++ b/app/views/topics/_node_info.html.erb
@@ -40,8 +40,8 @@
             <a href="<%= main_app.popular_topics_path %>" data-turbolinks-action="replace">优质帖子</a>
           </li>
           <% if admin? %>
-          <li class="<%= ' active' if action_name == 'ban' %>">
-            <%= link_to('已屏蔽', main_app.ban_topics_path, data: { 'turbolinks-action': 'replace' }) %>
+          <li class="<%= ' active' if action_name == 'banned' %>">
+            <%= link_to('已屏蔽', main_app.banned_topics_path, data: { 'turbolinks-action': 'replace' }) %>
           </li>
           <% end %>
           <% if !mobile? %>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -18,7 +18,7 @@
       </div>
 
       <div class="card-footer clearfix">
-        <% if action_name.in? %(index recent) %>
+        <% if (action_name.in? %(index recent)) && (controller_name == "topics") %>
           <%= paginate @topics, total_pages: Topic.total_pages %>
         <% else %>
           <%= paginate @topics %>

--- a/config/locales/topics.zh-CN.yml
+++ b/config/locales/topics.zh-CN.yml
@@ -15,6 +15,7 @@
       recent: "最新创建"
       last_reply: "最新回复"
       popular: "优质话题"
+      banned: "已屏蔽"
       no_reply: "无人问津"
       excellent: "精华帖"
     read_topic: "浏览话题"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,7 +76,7 @@ Rails.application.routes.draw do
       get :popular
       get :last
       get :last_reply
-      get :ban
+      get :banned
       get :excellent
       get :favorites
       get :feed, defaults: { format: "xml" }

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -51,9 +51,9 @@ describe TopicsController, type: :controller do
     end
   end
 
-  describe ":ban" do
-    it "should have a excellent action" do
-      get :ban
+  describe ":banned" do
+    it "should have a banned action" do
+      get :banned
       expect(response).to have_http_status(200)
     end
   end


### PR DESCRIPTION
#### Bug 1 (关联 issue #1055 分页 bug)
#### Bug 描述：

在招聘版下，会调用 Topic 下的 total_pages 逻辑，在招聘相关 topics 不足 1500 （无论是否进行城市筛选）但 topics 总数达到 1500 时，强制列出 60 页分页；点击靠后的分页时，实际并无内容展现。

#### 修复方式：

在 topics 列表页中将判断语句限制为仅在 TopicsController 下才调用 total_pages 逻辑。

#### 个人分析：

一开始的思路是想修改 total_pages 的逻辑使 topics 和 jobs 的分页逻辑分离，但因 jobs 部分本质上还是 Topic 的一个因外挂插件而产生的 scope，如果直接在 Topic 里写死 jobs 的逻辑，对于没有使用 jobs 插件而自己写了其他类似插件的用户，此 bug 依然会复现，问题依然得不到解决；最后选择让 jobs 不调用这条逻辑，但这样又会使招聘版的分页没有底层缓存……不知前辈们对此是否有些更好的思路，若有闲暇还希望能指点一二……


#### Bug 2
#### Bug 描述：

此 bug 为尝试解决以上 bug 时偶然发现的。在 ListAction Module 中的 ban action （筛选已被屏蔽的帖子）与 TopicsController 中的 ban action 产生了命名冲突，从而导致了点击『已屏蔽』按钮时错误调用 TopicsController#ban 的情况。同时『已屏蔽』页面的 title 错误显示为『最新创建』。

#### 修复方式：

将 ListAction 相关的 ban 重命名为 banned，并修改相关路由、页面链接、Locale 以及测试。

#### 测试结果：

Finished in 6 minutes 53 seconds (files took 7.75 seconds to load)

727 examples, 0 failures