### PR TITLE
Specify redis to use hiredis driver explicit

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -6,14 +6,14 @@ require "redis/objects"
 
 redis_config = Rails.application.config_for(:redis)
 
-$redis = Redis.new(host: redis_config["host"], port: redis_config["port"])
+$redis = Redis.new(host: redis_config["host"], port: redis_config["port"], driver: :hiredis)
 $redis.select(0)
 Redis::Objects.redis = $redis
 
 sidekiq_url = "redis://#{redis_config['host']}:#{redis_config['port']}/0"
 Sidekiq.configure_server do |config|
-  config.redis = { namespace: "sidekiq", url: sidekiq_url }
+  config.redis = { namespace: "sidekiq", url: sidekiq_url, driver: :hiredis }
 end
 Sidekiq.configure_client do |config|
-  config.redis = { namespace: "sidekiq", url: sidekiq_url }
+  config.redis = { namespace: "sidekiq", url: sidekiq_url, driver: :hiredis }
 end


### PR DESCRIPTION
According to https://github.com/redis/redis-rb#hiredis, we should pass `driver: :hiredis` as an option if we want to use hiredis.