### PR TITLE
修复新回复bug

### DIFF
--- a/app/assets/javascripts/topics.coffee
+++ b/app/assets/javascripts/topics.coffee
@@ -281,7 +281,11 @@ window.TopicView = Backbone.View.extend
         subscribe: ->
           @topicId = Topics.topic_id
           @perform 'follow', topic_id: Topics.topic_id
+
+        unfollow: ->
+          @perform 'unfollow'
     else if window.repliesChannel.topicId != Topics.topic_id
+      window.repliesChannel.unfollow()
       window.repliesChannel.subscribe()
 
   updateReplies: () ->

--- a/app/channels/replies_channel.rb
+++ b/app/channels/replies_channel.rb
@@ -4,4 +4,8 @@ class RepliesChannel < ApplicationCable::Channel
   def follow(data)
     stream_from "topics/#{data['topic_id']}/replies"
   end
+
+  def unfollow
+    stop_all_streams
+  end
 end


### PR DESCRIPTION
**重现步骤**
1. User A 进入 Topic A.
2. User A 进入 Topic B.
3. User B 在 Topic A 回复.

期望: User A 在 Topic A不会看到信回复的提醒。
实际: User A 看到了信回复提醒，点击<载入>, 并没有新回复被载入。

**Root Cause**
User A进入两个topic，subscribe了两个stream

**Solution**
在进入新Topic, 重新subscirbe前，先清理之前的stream