### PR TITLE
屏蔽非图片文件的上传

### DIFF
--- a/app/assets/javascripts/editor.coffee
+++ b/app/assets/javascripts/editor.coffee
@@ -26,6 +26,8 @@ window.Editor = Backbone.View.extend
       paramName: "file"
       maxFilesize: 20
       uploadMultiple: false
+      acceptedFiles: 'image/*'
+      capture: 'image/'
       headers:
         "X-CSRF-Token": $("meta[name=\"csrf-token\"]").attr("content")
       previewContainer: false


### PR DESCRIPTION
目前，可以传 js 文件 eg: https://l.ruby-china.com/photo/2018/e8af7717-3702-4f0a-9617-d4a56861cec2.js