### PR TITLE
Fix: 本地文件上传，URL做图路路由错误

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
     root to: "topics#index"
   end
   match "/uploads/:path(![large|lg|md|sm|xs])", to: "home#uploads", via: :get, constraints: {
-    path: /[\w\d\.\/]+/i
+    path: /[\w\d\.\/\-]+/i
   }
 
   devise_for :users, path: "account", controllers: {


### PR DESCRIPTION
原因： commit https://github.com/ruby-china/homeland/commit/ecf5543371aaee52663f548535dbe2e7237def88#diff-754caf21f266ab6dc2451900df6c835d 修改了上传文件名为 UUID，文件名中开始有了横线，URL 做图路由不匹配，会最终匹配到路由 ```  match "*path", to: "home#error_404", via: :all ``` 去

方案：
URL 做图路由中正则表达式增加横线 ```path: /[\w\d\.\/\-]+/i```