### PR TITLE
FixBug, 显示逻辑不匹配

### DIFF
--- a/app/views/replies/create.js.erb
+++ b/app/views/replies/create.js.erb
@@ -1,5 +1,5 @@
 <% if !@reply.errors.blank? %>
-  _topicView.replyCallback(0, '<%= j(@msg) %>');
+  _topicView.replyCallback(0, '<%= raw(@msg) %>');
 <% else %>
   <% if @reply.upvote? %>
     Turbolinks.visit(location.href);


### PR DESCRIPTION
https://github.com/ruby-china/homeland/blob/f402be00446cd1a269baf8feb74e7ec0be24a65d/app/controllers/replies_controller.rb#L18

view 内用 ``` j ``` 后 ``` <br/>```  会被替换为 ```  &lt;br/&gt;  ``` 原样显示在页面上。