### PR TITLE
修复移动设备下，文章的目录无法正常显示的问题

### DIFF
--- a/app/assets/stylesheets/toc.scss
+++ b/app/assets/stylesheets/toc.scss
@@ -58,8 +58,8 @@
       top: 0;
       left: 0;
       width: 100%;
-      height: 100%;
-      max-height: 100%;
+      height: auto;
+      max-height: none;
       padding: 15px;
 
       .list-container {


### PR DESCRIPTION
issue #1081
在移动设备下，文章的目录按钮点击后，列表无法正常显示.
原因是列表的上层div 限制了
```css
height: 100%;
max-height: 100%;
```

修改为
```css
height: auto;
max-height: none;
```
可以显示完整的列表