### PR TITLE
修正手机端图片浏览

### DIFF
--- a/app/assets/javascripts/editor.coffee
+++ b/app/assets/javascripts/editor.coffee
@@ -27,7 +27,6 @@ window.Editor = Backbone.View.extend
       maxFilesize: 20
       uploadMultiple: false
       acceptedFiles: 'image/*'
-      capture: 'image/'
       headers:
         "X-CSRF-Token": $("meta[name=\"csrf-token\"]").attr("content")
       previewContainer: false


### PR DESCRIPTION
设置 capture 会导致手机网页或 app 内的图片上传时仅能直接拍照，而不能浏览相册和文稿等已有图片