### PR TITLE
remove the useless equal-sign

### DIFF
--- a/app/views/notifications/notifications/_notification.html.erb
+++ b/app/views/notifications/notifications/_notification.html.erb
@@ -1,4 +1,4 @@
-<%= cache(['notifications', Notifications::VERSION, notification, notification.actor, notification.read?]) do %>
+<% cache(['notifications', Notifications::VERSION, notification, notification.actor, notification.read?]) do %>
 <div id="notification-<%= notification.id %>"
      data-id="<%= notification.id %>"
      class="media notification notification-<%= notification.notify_type %><%= ' unread' if !notification.read? %>">


### PR DESCRIPTION
remove the useless equal-sign, which will render a empty newline in html source