### PR TITLE
解决了Recaptcha在国内访问，无法验证的问题

### DIFF
--- a/config/initializers/rucaptcha.rb
+++ b/config/initializers/rucaptcha.rb
@@ -7,6 +7,7 @@ end
 
 Recaptcha.configure do |config|
   config.api_server_url = "https://recaptcha.net/recaptcha/api.js"
+  config.verify_url = "https://recaptcha.net/recaptcha/api/siteverify"
 end
 
 module ComplexCaptchaHelper


### PR DESCRIPTION
原始代码只有
```ruby
config.api_server_url = "https://recaptcha.net/recaptcha/api.js"
```
此代码在国内可以正常显示，但无法验证。现在又增加了：

```ruby
config.verify_url = "https://recaptcha.net/recaptcha/api/siteverify"
```