### PR TITLE
Fix ActionView::MissingTemplate

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,7 +72,7 @@ class ApplicationController < ActionController::Base
 
     respond_to do |format|
       format.html { render template: "/errors/#{fname}", handler: [:erb], status: status, layout: "application" }
-      format.all  { render nothing: true, status: status }
+      format.all { render body: nil, status: status }
     end
   end
 


### PR DESCRIPTION
rails 5.1 开始不支持 ``` nothing: true ```的写法
会导致 ```ActionView::MissingTemplate``` 错误 , 
例如访问: https://ruby-china.org/abc/38901.php

ref: https://github.com/rails/rails/blob/5-0-stable/actionpack/lib/action_controller/metal/rendering.rb#L102

由于 exception-track 忽略了 ```ActionView::MissingTemplate```，所以后台看不到这个错误记录
https://github.com/ruby-china/homeland/blob/master/config/initializers/exception-track.rb#L14
但在 NewRelic 里可以抓到好多这个错误，都是爬虫爬过来的。