### PR TITLE
新增版主权限，以及用户等级（角色）重新调整

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -699,6 +699,16 @@ img.emoji {
   text-align: center;
 }
 
+/* User role */
+.badge-role {
+  @extend .badge;
+  font-size: 12px;
+  font-weight: normal;
+  font-family: sans-serif;
+  background: #564cf5;
+  color: #fff;
+}
+
 .opts a.active {
   .fa {
     @extend .animated;

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -5,12 +5,12 @@ module ApplicationCable
     identified_by :current_user_id
 
     def connect
-      self.current_user_id = find_verified_user_id
+      self.current_user_id = find_cookie_user_id
     end
 
     protected
 
-      def find_verified_user_id
+      def find_cookie_user_id
         cookies.signed[:user_id] || nil
       end
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,9 +4,8 @@ module Admin
   class UsersController < Admin::ApplicationController
     def index
       scope = User.all
-      if params[:type].present?
-        scope = scope.where(type: params[:type])
-      end
+      scope = scope.where(type: params[:type]) if params[:type].present?
+      scope = scope.where(state: params[:state]) if params[:state].present?
       field = params[:field] || "login"
 
       if params[:q].present?
@@ -44,7 +43,6 @@ module Admin
       @user.email = params[:user][:email]
       @user.login = params[:user][:login]
       @user.state = params[:user][:state]
-      @user.verified = params[:user][:verified]
 
       if @user.save
         redirect_to(admin_users_path, notice: "User was successfully created.")
@@ -58,7 +56,6 @@ module Admin
       @user.email = params[:user][:email]
       @user.login = params[:user][:login]
       @user.state = params[:user][:state]
-      @user.verified = params[:user][:verified]
 
       if @user.update(params[:user].permit!)
         redirect_to(edit_admin_user_path(@user.id), notice: "User was successfully updated.")

--- a/app/controllers/api/v3/application_controller.rb
+++ b/app/controllers/api/v3/application_controller.rb
@@ -13,7 +13,7 @@ module Api
       skip_before_action :verify_authenticity_token
 
       helper_method :can?, :current_user, :current_ability, :meta
-      helper_method :admin?, :owner?, :markdown, :raw
+      helper_method :owner?, :markdown, :raw
 
       # 参数值不在允许的范围内
       # HTTP Status 400

--- a/app/controllers/api/v3/topics_controller.rb
+++ b/app/controllers/api/v3/topics_controller.rb
@@ -106,11 +106,11 @@ module Api
 
         raise AccessDenied unless can?(:update, @topic)
 
-        if @topic.lock_node == false || admin?
+        if @topic.lock_node == false || can?(:lock_node, @topic)
           # 锁定接点的时候，只有管理员可以修改节点
           @topic.node_id = params[:node_id]
 
-          if admin? && @topic.node_id_changed?
+          if @topic.node_id_changed? || can?(:lock_node, @topic)
             # 当管理员修改节点的时候，锁定节点
             @topic.lock_node = true
           end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -90,7 +90,7 @@ class TopicsController < ApplicationController
       # 锁定接点的时候，只有管理员可以修改节点
       @topic.node_id = topic_params[:node_id]
 
-      if current_user.admin? && @topic.node_id_changed?
+      if @topic.node_id_changed? && can?(:lock_node, @topic)
         # 当管理员修改节点的时候，锁定节点
         @topic.lock_node = true
       end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,12 +29,14 @@ module ApplicationHelper
 
   def admin?(user = nil)
     user ||= current_user
-    user&.admin? == true
+    return false if user.blank?
+    user.admin?
   end
 
   def wiki_editor?(user = nil)
     user ||= current_user
-    user&.wiki_editor? == true
+    return false if user.blank?
+    user.wiki_editor?
   end
 
   def owner?(item)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,6 +27,7 @@ module ApplicationHelper
     flash_messages.join("\n").html_safe
   end
 
+  # used in Plugin
   def admin?(user = nil)
     user ||= current_user
     return false if user.blank?

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -64,18 +64,9 @@ module UsersHelper
     end
   end
 
-  def render_user_level_tag(user)
+  def user_level_tag(user)
     return "" if user.blank?
-    level_class = case user.level
-                  when "admin"   then "badge-danger"
-                  when "vip"     then "badge-success"
-                  when "hr"      then "badge-success"
-                  when "blocked" then "badge-warning"
-                  when "newbie"  then "badge-light"
-                  else "badge-info"
-    end
-
-    content_tag(:span, user.level_name, class: "badge #{level_class} role")
+    content_tag(:span, user.level_name, class: "badge-role role-#{user.level}", style: "background: #{user.level_color};")
   end
 
   def block_node_tag(node)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -54,6 +54,7 @@ class Ability
       can :manage, Node
       can :manage, Section
       can :manage, Topic
+      can :lock_node, Topic
       can :manage, Reply
     end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -9,10 +9,13 @@ class Ability
     @user = u
     if @user.blank?
       roles_for_anonymous
-    elsif @user.roles?(:admin)
+    elsif @user.admin?
       can :manage, :all
-    elsif @user.roles?(:member)
+    elsif @user.member?
       roles_for_members
+    elsif @user.vip?
+      roles_for_members
+      roles_for_vip
     else
       roles_for_anonymous
     end
@@ -35,6 +38,11 @@ class Ability
     def roles_for_anonymous
       cannot :manage, :all
       basic_read_only
+    end
+
+    # Vip 用户权限
+    def roles_for_vip
+      can :create, Team
     end
 
     def roles_for_topics
@@ -76,9 +84,6 @@ class Ability
     end
 
     def roles_for_teams
-      if user.roles?(:wiki_editor)
-        can :create, Team
-      end
       can [:update, :destroy], Team do |team|
         team.owner?(user)
       end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -16,6 +16,9 @@ class Ability
     elsif @user.vip?
       roles_for_members
       roles_for_vip
+    elsif @user.maintainer?
+      roles_for_members
+      roles_for_maintainer
     else
       roles_for_anonymous
     end
@@ -43,6 +46,15 @@ class Ability
     # Vip 用户权限
     def roles_for_vip
       can :create, Team
+    end
+
+    # 版主权限
+    def roles_for_maintainer
+      can :create, Team
+      can :manage, Node
+      can :manage, Section
+      can :manage, Topic
+      can :manage, Reply
     end
 
     def roles_for_topics

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -158,11 +158,6 @@ class Setting < RailsSettings::Base
       [self.protocol, self.domain].join("://")
     end
 
-    def has_admin?(email)
-      return false if self.admin_emails.blank?
-      self.admin_emails.map { |str| str.strip }.include?(email)
-    end
-
     def has_module?(name)
       return true if self.modules.blank? || self.modules.include?("all")
       self.modules.map { |str| str.strip }.include?(name.to_s)

--- a/app/models/topic/notify.rb
+++ b/app/models/topic/notify.rb
@@ -48,10 +48,11 @@ class Topic
 
     private
       def notify_admin_editing_node_changed
-        return unless Current.user&.admin?
         return unless self.node_id_changed?
 
-        Topic.notify_topic_node_changed(id, node_id)
+        if Current.user&.admin? || Current.user&.maintainer?
+          Topic.notify_topic_node_changed(id, node_id)
+        end
       end
 
       def async_create_reply_notification

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,9 +33,6 @@ class User < ApplicationRecord
 
   attr_accessor :password_confirmation
 
-
-  enum state: { deleted: -1, normal: 1, blocked: 2 }
-
   validates :login, format: { with: ALLOW_LOGIN_FORMAT_REGEXP, message: "只允许数字、大小写字母、中横线、下划线" },
                     length: { in: 2..20 },
                     presence: true,
@@ -48,7 +45,7 @@ class User < ApplicationRecord
   scope :without_team, -> { where(type: nil) }
   scope :fields_for_list, lambda {
     select(:type, :id, :name, :login, :email, :email_md5, :email_public,
-           :avatar, :verified, :state, :tagline, :github, :website, :location,
+           :avatar, :state, :tagline, :github, :website, :location,
            :location_id, :twitter, :team_users_count, :created_at, :updated_at)
   }
 

--- a/app/models/user/roles.rb
+++ b/app/models/user/roles.rb
@@ -17,12 +17,12 @@ class User
 
     # 是否有 Wiki 维护权限
     def wiki_editor?
-      self.admin? || self.vip?
+      self.admin? || self.maintainer? || self.vip?
     end
 
     # 回帖大于 150 的才有酷站的发布权限
     def site_editor?
-      self.admin? || replies_count >= 100
+      self.admin? || self.maintainer? || replies_count >= 100
     end
 
     # 是否能发帖

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -78,12 +78,6 @@
   </div>
 
   <% if @user.user_type == :user %>
-
-    <div class="form-group form-check">
-      <%= f.check_box :verified, class: "form-check-input" %>
-      <%= f.label :verified, class: "form-check-label" %>
-    </div>
-
     <div class="form-group">
       <%= f.label :state %>
       <%= f.select :state, User.state_options, {}, class: "form-control" %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -12,6 +12,9 @@
     <div class="form-group mr-sm-2">
       <%= select_tag(:type, options_for_select([['全部类别',''], ['组织','Team']], params[:type]), class: 'form-control') %>
     </div>
+    <div class="form-group mr-sm-2">
+      <%= select_tag(:state, options_for_select(User.state_options, params[:state]), class: 'form-control', include_blank: "所有等级") %>
+    </div>
     <button class="btn btn-default">搜索</button>
   </form>
 </div>
@@ -19,9 +22,8 @@
 <table class="table table-bordered table-striped table-condensed">
   <tr class="head">
     <td class="first">#</td>
+    <td>头像</td>
     <td>帐号</td>
-    <td>姓名</td>
-    <td>Email</td>
     <td>注册时间</td>
     <td>操作</td>
   </tr>
@@ -29,10 +31,11 @@
 <% @users.each do |user| %>
   <tr>
     <td class="first"><%= user.id %></td>
-    <td><%= user_name_tag(user) %></td>
-    <td><%= user.name %></td>
-    <td><%= user.email %></td>
-    <td><%= user.created_at&.to_date %></td>
+    <td width="32"><%= user_avatar_tag(user, :sm) %></td>
+    <td>
+      <%= link_to user.fullname, user_path(user), target: "_blank" %> <%= user_level_tag(user) unless user.member? %>
+    </td>
+    <td width="120"><%= user.created_at&.to_date %></td>
     <td>
       <%= link_to '', edit_admin_user_path(user.id), class: "fa fa-pencil" %>
     </td>

--- a/app/views/devise/menu/_registration_items.html.erb
+++ b/app/views/devise/menu/_registration_items.html.erb
@@ -2,7 +2,7 @@
 你好 <strong><a href="<%= user_path(current_user.login)%>"><%= current_user.login %></a></strong>,
 <% if not params[:controller].match(/admin/) %>
   <%= link_to('设置', setting_path) %> |
-  <% if admin? current_user %><a href="/admin">后台</a> | <% end %>
+  <% if current_user&.admin? %><a href="/admin">后台</a> | <% end %>
 <% end %>
 <% else %>
   <%= link_to('加入社区', new_user_registration_path)  %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -48,6 +48,7 @@
 
   <footer class="footer">
     <div class="container">
+      <p>Powered by <a href="https://github.com/ruby-china/homeland/releases">Homeland <%= Homeland.version %></a></p>
       <p class="suggest">使用 <a href="http://www.mozillaonline.com/" target="_blank" rel="nofollow">Firefox</a> 或 <a href="http://www.google.com/chrome" target="_blank" rel="nofollow">Chrome</a> 浏览访问本站将会获得更佳的视觉体验.</p>
     </div>
   </footer>

--- a/app/views/search/_user.html.erb
+++ b/app/views/search/_user.html.erb
@@ -9,7 +9,7 @@
     <div class="media-body">
       <div class="info">
         <%= link_to item.fullname, item %>
-        <span class="level"><%= render_user_level_tag(item) %></span>
+        <span class="level"><%= user_level_tag(item) %></span>
       </div>
       <div class="info number">
         第 <%= item.id %> 位<%= t("menu.users")%>

--- a/app/views/shared/_usernav.html.erb
+++ b/app/views/shared/_usernav.html.erb
@@ -35,7 +35,7 @@
           <%= link_to plugin.display_name, plugin.root_path, class: "dropdown-item" %>
         <% end %>
 
-        <% if admin? %>
+        <% if current_user&.admin? %>
           <div class="dropdown-divider"></div>
           <% if params[:controller].start_with?("admin/") %>
             <%= link_to "回到前台", main_app.root_path, class: "dropdown-item" %>

--- a/app/views/topics/_buttons.html.erb
+++ b/app/views/topics/_buttons.html.erb
@@ -5,7 +5,7 @@
     <%= topic_favorite_tag(@topic) %>
   <% end %>
 
-  <% if admin? %>
+  <% if can? :suggest, @topic %>
     <% if !@topic.suggested_at.blank? %>
     <%= link_to raw("<i class='fa fa-angle-double-up'></i> 取消"), unsuggest_admin_topic_path(@topic), method: :post, remote: true %>
     <% else %>
@@ -22,7 +22,6 @@
     <% end %>
   <% end %>
   <span class="pull-right opts">
-    <% if owner?(@topic) or admin? %>
     <% if can?(:close, @topic) %>
       <% if !@topic.closed? %>
         <%= link_to raw("<i class='fa fa-check'></i>"), action_topic_path(@topic, type: 'close'), method: 'post', title: "关闭讨论／问题已解决", remote: true, data: { toggle: 'tooltip' } %>
@@ -30,10 +29,12 @@
         <%= link_to raw("<i class='fa fa-undo'></i>"), action_topic_path(@topic, type: 'open'), method: 'post', title: "重新开启话题", remote: true, data: { toggle: 'tooltip' } %>
       <% end %>
     <% end %>
+
+    <% if can?(:edit, @topic) %>
     <%= link_to "", edit_topic_path(@topic), class: "fa fa-pencil", title: "修改本帖" %>
-      <% if can?(:destroy, @topic) %>
-      <%= link_to "", topic_path(@topic.id), method: :delete, remote: true, 'data-confirm': t("common.confirm_delete"), class: "fa fa-trash", title: "删除本帖" %>
-      <% end %>
+    <% end %>
+    <% if can?(:destroy, @topic) %>
+    <%= link_to "", topic_path(@topic.id), method: :delete, remote: true, 'data-confirm': t("common.confirm_delete"), class: "fa fa-trash", title: "删除本帖" %>
     <% end %>
   </span>
 </div>

--- a/app/views/topics/_node_info.html.erb
+++ b/app/views/topics/_node_info.html.erb
@@ -28,7 +28,7 @@
           <li class="<%= ' active' if action_name == 'popular' %>">
             <a href="<%= main_app.popular_topics_path %>" data-turbolinks-action="replace">优质帖子</a>
           </li>
-          <% if admin? %>
+          <% if can?(:ban, Topic) %>
             <li class="<%= ' active' if action_name == 'banned' %>">
               <%= link_to('已屏蔽', main_app.banned_topics_path, data: { 'turbolinks-action': 'replace' }) %>
             </li>

--- a/app/views/topics/_topic_sidebar.html.erb
+++ b/app/views/topics/_topic_sidebar.html.erb
@@ -26,7 +26,7 @@
       </div>
       <hr />
       <div class="group opts">
-        <% if admin? %>
+        <% if can?(:manage, @topic) %>
           <div style="margin-bottom: 8px">
             <% if !@topic.suggested_at.blank? %>
             <%= link_to raw("<i class='fa fa-angle-double-up'></i> 取消"), unsuggest_admin_topic_path(@topic), method: :post, remote: true %>
@@ -45,7 +45,6 @@
           </div>
         <% end %>
 
-        <% if owner?(@topic) or admin? %>
         <div>
           <% if can?(:close, @topic) %>
             <% if !@topic.closed? %>
@@ -54,12 +53,13 @@
               <%= link_to raw("<i class='fa fa-undo'></i> 开启"), action_topic_path(@topic, type: 'open'), method: 'post', title: "重新开启话题", remote: true, data: { toggle: 'tooltip' } %>
             <% end %>
           <% end %>
+          <% if can?(:edit, @topic) %>
           <%= link_to raw('<i class="fa fa-pencil"></i> 编辑'), edit_topic_path(@topic), title: "修改本帖" %>
+          <% end %>
           <% if can?(:destroy, @topic) %>
             <%= link_to raw('<i class="fa fa-trash"></i> 删除'), topic_path(@topic.id), method: :delete, 'data-confirm' => t("common.confirm_delete"), title: "删除本帖", remote: true %>
           <% end %>
         </div>
-        <% end %>
       </div>
       <a href="#" class="btn btn-default btn-sm btn-block btn-move-page" data-type="bottom"><i class="fa fa-arrow-down"></i></a>
     </div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,5 +1,4 @@
 <% title_tag @topic.title %>
-
 <% content_for :scripts do %>
   <script type="text/javascript">
     Topics.topic_id = <%= @topic.id %>;
@@ -7,100 +6,89 @@
     Topics.user_liked_reply_ids = [<%= @user_like_reply_ids.join(",") %>];
     <% end %>
     $(document).ready(function(){
-      <% if admin? %>
+      <% if can?(:manage, Reply) %>
         $("#replies .reply a.edit").css('display','inline-block');
       <% elsif current_user %>
         $("#replies .reply a.edit[data-uid='<%= current_user.id %>']").css('display','inline-block');
       <% end %>
-
+    
       <% if @topic.closed? %>
         $("#replies .reply .hideable").remove();
       <% end %>
     })
   </script>
 <% end %>
-
 <div class="row">
   <div class="col-md-9">
     <div class="topic-detail card">
       <%= render partial: "topics/topic_info", locals: { topic: @topic } %>
-
       <% if @topic.excellent? %>
         <div class="label-awesome">
           <i class="fa fa-diamond awesome"></i> 本帖已被设为精华帖！
-          <% if admin? %>
-          <div class="pull-right">
-            <%= link_to icon_tag("close"), action_topic_path(@topic.id, type: 'normal'), method: :post, remote: true %>
-          </div>
+          <% if can?(:close, @topic) %>
+            <div class="pull-right">
+              <%= link_to icon_tag("close"), action_topic_path(@topic.id, type: 'normal'), method: :post, remote: true %>
+            </div>
           <% end %>
         </div>
       <% end %>
-
       <div class="card-body markdown markdown-toc">
         <%= raw Setting.before_topic_html %>
-
         <%= @topic.body_html %>
-
         <%= raw Setting.after_topic_html %>
       </div>
-
       <div class="card-footer clearfix">
         <%= render "buttons" %>
       </div>
     </div>
-
     <%= render partial: "ban_reason" %>
-
-  <% if @replies.blank? %>
-    <div class="no-result">
-      <%= t("topics.no_replies") %>
-    </div>
-    <% else %>
-    <div id="replies" class="card" data-last-floor="<%= @replies.count(:all) %>">
-      <div class="items card-body">
-        <%= render partial: "/replies/reply", collection: @replies %>
+    <% if @replies.blank? %>
+      <div class="no-result">
+        <%= t("topics.no_replies") %>
       </div>
-    </div>
-  <% end %>
-
-  <% if current_user %>
-    <% if @topic.closed? %>
-      <div class="alert alert-info">此话题已经于 <%= l @topic.closed_at, format: :long %> 关闭，不再接受任何回帖。</div>
     <% else %>
-      <div id="reply" class="card">
-        <div class="card-body">
-          <div class="card-title hide-ios">发起回帖</div>
-          <% if can? :create, Reply %>
-            <%= render 'reply_form' %>
-          <% else %>
-            <div class="alert alert-info">
-              当前设置新手用户不能在 22:00 ~ 9:00 发帖。
-            </div>
-          <% end %>
+      <div id="replies" class="card" data-last-floor="<%= @replies.count(:all) %>">
+        <div class="items card-body">
+          <%= render partial: "/replies/reply", collection: @replies %>
         </div>
       </div>
     <% end %>
-  <% else %>
-    <div class="card">
-      <div class="card-body">
-        <%= render partial: "topics/translation/need_login_to_reply" %>
+    <% if current_user %>
+      <% if @topic.closed? %>
+        <div class="alert alert-info">此话题已经于 <%= l @topic.closed_at, format: :long %> 关闭，不再接受任何回帖。</div>
+      <% else %>
+        <div id="reply" class="card">
+          <div class="card-body">
+            <div class="card-title hide-ios">发起回帖</div>
+            <% if can? :create, Reply %>
+              <%= render 'reply_form' %>
+            <% else %>
+              <div class="alert alert-info">
+                当前设置新手用户不能在 22:00 ~ 9:00 发帖。
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    <% else %>
+      <div class="card">
+        <div class="card-body">
+          <%= render partial: "topics/translation/need_login_to_reply" %>
+        </div>
       </div>
+    <% end %>
+    <% if !mobile? %>
+      <%= render 'related_topics' %>
+    <% end %>
+  </div>
+  <% if !mobile? %>
+    <div class="sidebar hidden-mobile col-md-3">
+      <%= render 'topic_sidebar' %>
+    </div>
+  <% else %>
+    <div class="move-page-buttons">
+      <a href="#" class="btn btn-block btn-sm btn-move-page" data-type="top"><i class="fa fa-arrow-up"></i></a>
+      <a href="#" class="btn btn-block btn-sm btn-move-page" data-type="bottom"><i class="fa fa-arrow-down"></i></a>
     </div>
   <% end %>
-
-  <% if !mobile? %>
-  <%= render 'related_topics' %>
-  <% end %>
-</div>
-
-<% if !mobile? %>
-  <div class="sidebar hidden-mobile col-md-3">
-    <%= render 'topic_sidebar' %>
-  </div>
-<% else %>
-  <div class="move-page-buttons">
-    <a href="#" class="btn btn-block btn-sm btn-move-page" data-type="top"><i class="fa fa-arrow-up"></i></a>
-    <a href="#" class="btn btn-block btn-sm btn-move-page" data-type="bottom"><i class="fa fa-arrow-down"></i></a>
-  </div>
-<% end %>
 </div>

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -10,8 +10,8 @@
           <div class="item">
             <%= @user.fullname %>
             <span class="opts pull-right">
-              <% if admin? %>
-                <%= link_to icon_tag("pencil", label: "修改"), edit_admin_user_path(@user.id) %>
+              <% if current_user&.admin? %>
+                <%= link_to icon_tag("pencil", label: "管理"), edit_admin_user_path(@user.id) %>
               <% end %>
             </span>
           </div>
@@ -19,10 +19,10 @@
             第 <%= @user.id %> 位<%= t("menu.users")%> / <span title="注册日期"><%= @user.created_at.to_date %></span>
           </div>
           <% if !@user.company.blank? %>
-          <div class="item company">
-            <%= @user.company %>
-            <% if @user.location.present? %> @ <span title="所在地"><%= location_name_tag(@user.location) %></span><% end %>
-          </div>
+            <div class="item company">
+              <%= @user.company %>
+              <% if @user.location.present? %> @ <span title="所在地"><%= location_name_tag(@user.location) %></span><% end %>
+            </div>
           <% end %>
           <div class="item counts">
             <span><%= @user.topics_count %></span> 篇帖子 • <span><%= @user.replies_count %></span> 条回帖
@@ -31,17 +31,14 @@
             <% if !@user.twitter.blank? %>
               <%= link_to raw('<i class="fa fa-twitter"></i>'), @user.twitter_url, class: "twitter", rel: "nofollow" %>
             <% end %>
-
             <% if !@user.website.blank? %>
               <%= link_to(raw('<i class="fa fa-globe"></i>'), @user.website_url, target: '_blank', rel: 'nofollow') %>
             <% end %>
-
             <% if Setting.has_module? :github %>
               <% if !@user.github.blank? %>
                 <%= link_to(raw('<i class="fa fa-github"></i>'), @user.github_url, target: '_blank', rel: 'nofollow') %>
               <% end %>
             <% end %>
-
             <% if !@user.email.blank? && @user.email_public %>
               <a href="mailto: <%= @user.email %>"><i class="fa fa-envelope-o"></i></a>
             <% end %>
@@ -63,40 +60,35 @@
         </div>
       </div>
       <% if !owner? @user %>
-      <div class="buttons row">
-        <div class="col-sm-6">
-          <%= follow_user_tag(@user) %>
+        <div class="buttons row">
+          <div class="col-sm-6">
+            <%= follow_user_tag(@user) %>
+          </div>
+          <div class="col-sm-6">
+            <%= block_user_tag(@user) %>
+          </div>
         </div>
-
-        <div class="col-sm-6">
-          <%= block_user_tag(@user) %>
-        </div>
-      </div>
       <% end %>
-
       <% if !@user.tagline.blank? %>
-      <div class="tagline row">
-        <%= @user.tagline %>
-      </div>
+        <div class="tagline row">
+          <%= @user.tagline %>
+        </div>
       <% end %>
-
       <div class="buttons">
         <%= reward_user_tag(@user, class: "btn btn-block btn-default") %>
       </div>
     </div>
   </div>
-
   <% if Setting.has_module?(:team) %>
     <% if !@user.teams.blank? %>
-    <div class="card user-teams">
-      <div class="card-body">
-        <% @user.teams.each do |team| %>
-          <%= user_avatar_tag(team, :md) %>
-        <% end %>
+      <div class="card user-teams">
+        <div class="card-body">
+          <% @user.teams.each do |team| %>
+            <%= user_avatar_tag(team, :md) %>
+          <% end %>
+        </div>
       </div>
-    </div>
     <% end %>
   <% end %>
-
   <%= render '/users/repos', user: @user %>
 </div>

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -4,7 +4,7 @@
       <div class="media">
         <div class="avatar media-left mr-3">
           <div class='image'><%= user_avatar_tag(@user, :lg, link: false) %></div>
-          <div class="level"><%= render_user_level_tag(@user) %></div>
+          <div class="level"><%= user_level_tag(@user) %></div>
         </div>
         <div class="media-body">
           <div class="item">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,7 +31,6 @@ en:
         last_logined_at: "Last signed in at"
         tagline: "Tagline"
         state: "Status"
-        verified: "Verified"
         company: "Company"
         github: "GitHub"
         remember_me: "Remember me"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -20,13 +20,23 @@
     enums:
       user:
         state:
-          deleted: 删除
-          normal: 正常
-          blocked: 禁言
+          deleted: 已注销
+          newbie: 新手
+          member: 会员
+          blocked: 禁言用户
+          vip: 高级会员
+          hr: HR
+          maintainer: 版主
+          admin: 管理员
         state_color:
-          deleted: "yellow"
-          normal: "green"
-          blocked: "red"
+          deleted: 已注销
+          newbie: "#564cf5"
+          member: "#564cf5"
+          blocked: "#505050"
+          vip: "#12ce0f"
+          hr: "#12ce0f"
+          maintainer: "#c800cc"
+          admin: "#f54821"
     models:
       user: "用户"
       topic: "话题"
@@ -47,8 +57,7 @@
         website: "个人主页"
         last_logined_at: "上次登录时间"
         tagline: "签名"
-        state: "状态"
-        verified: "信任用户"
+        state: "等级"
         company: "公司"
         github: "GitHub"
         remember_me: 记住登录状态

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -30,8 +30,7 @@
         website: "個人主頁"
         last_logined_at: "上次登錄時間"
         tagline: "簽名"
-        state: "狀態"
-        verified: "信任用戶"
+        state: "等級"
         company: "公司"
         github: "GitHub"
         remember_me: 記住登陸狀態

--- a/db/migrate/20200213140928_upgrade_user_state.rb
+++ b/db/migrate/20200213140928_upgrade_user_state.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class UpgradeUserState < ActiveRecord::Migration[6.0]
+  def up
+    # vip: 3, admin: 99
+    execute <<-SQL
+      UPDATE users SET state = 3 WHERE verified = true
+    SQL
+    admin_user_ids = User.where(email: Setting.admin_emails).pluck(:id)
+    if admin_user_ids.any?
+      execute <<-SQL
+        UPDATE users SET state = 99 WHERE id IN (#{admin_user_ids.join(",")})
+      SQL
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +13,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_02_13_155459) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -35,6 +36,14 @@ ActiveRecord::Schema.define(version: 2020_02_13_155459) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["provider", "uid"], name: "index_authorizations_on_provider_and_uid"
+  end
+
+  create_table "commentable_pages", force: :cascade do |t|
+    t.string "name"
+    t.integer "user_id"
+    t.integer "comments_count", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "comments", id: :serial, force: :cascade do |t|
@@ -73,6 +82,14 @@ ActiveRecord::Schema.define(version: 2020_02_13_155459) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["name"], name: "index_locations_on_name"
+  end
+
+  create_table "monkeys", force: :cascade do |t|
+    t.string "name"
+    t.integer "user_id"
+    t.integer "comments_count"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "nodes", id: :serial, force: :cascade do |t|
@@ -283,6 +300,15 @@ ActiveRecord::Schema.define(version: 2020_02_13_155459) do
     t.index ["user_id"], name: "index_team_users_on_user_id"
   end
 
+  create_table "test_documents", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "reply_to_id"
+    t.integer "mentioned_user_ids", default: [], array: true
+    t.text "body"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "topics", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "node_id", null: false
@@ -378,6 +404,14 @@ ActiveRecord::Schema.define(version: 2020_02_13_155459) do
     t.index ["location"], name: "index_users_on_location"
     t.index ["login"], name: "index_users_on_login", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
+  end
+
+  create_table "walking_deads", force: :cascade do |t|
+    t.string "name"
+    t.string "tag"
+    t.datetime "deleted_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
 end

--- a/lib/homeland/sso.rb
+++ b/lib/homeland/sso.rb
@@ -62,6 +62,9 @@ module Homeland
       user.name = name if user.name.blank?
       user.bio = bio if user.bio.blank?
 
+      # Add as admin
+      user.state = :admin if admin == true
+
       # change external attributes for sso record
       sso_record.username = username
       sso_record.email = email
@@ -70,15 +73,6 @@ module Homeland
 
       user.save!
       user.update_tracked_fields!(request)
-
-      # Add as admin
-      if admin == true
-        unless Setting.has_admin?(email)
-          emails = Setting.admin_emails
-          emails << email
-          Setting.admin_emails = emails
-        end
-      end
 
       sso_record.save!
       sso_record&.user

--- a/test/controllers/auth/sso_controller_test.rb
+++ b/test/controllers/auth/sso_controller_test.rb
@@ -130,8 +130,7 @@ describe Auth::SSOController do
       assert_redirected_to "/hello/world"
 
       user = User.find_by_email(sso.email)
-      assert_equal true, user.admin?
-      assert_equal true, Setting.has_admin?(sso.email)
+      assert_equal "admin", user.state
     end
 
     it "show error when create failure" do
@@ -186,8 +185,8 @@ describe Auth::SSOController do
     end
 
     it "should work" do
-      sign_in user
-      Setting.stubs(:has_admin?).returns(true)
+      admin = create(:admin)
+      sign_in admin
       get provider_auth_sso_path, params: Rack::Utils.parse_query(@sso.payload)
       assert_equal 302, response.status
 
@@ -198,10 +197,10 @@ describe Auth::SSOController do
       payload = location.split("?")[1]
       sso2 = SingleSignOn.parse(payload, @sso.sso_secret)
 
-      assert_equal user.email, sso2.email
-      assert_equal user.name, sso2.name
-      assert_equal user.login, sso2.username
-      assert_equal user.id.to_s, sso2.external_id
+      assert_equal admin.email, sso2.email
+      assert_equal admin.name, sso2.name
+      assert_equal admin.login, sso2.username
+      assert_equal admin.id.to_s, sso2.external_id
       refute_equal nil, sso2.avatar_url
       assert_equal true, sso2.admin
     end

--- a/test/controllers/teams_controller_test.rb
+++ b/test/controllers/teams_controller_test.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe TeamsController do
-  let(:user) { create :wiki_editor }
+  let(:user) { create :vip }
 
   it "GET /teams" do
     get teams_path

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -9,7 +9,6 @@ FactoryBot.define do
     password_confirmation { "password" }
     location { "China" }
     created_at { 100.days.ago }
-    verified { false }
   end
 
   factory :avatar_user, parent: :user do
@@ -17,15 +16,11 @@ FactoryBot.define do
   end
 
   factory :admin, parent: :user do
-    email { Setting.admin_emails.first }
+    state { "admin" }
   end
 
-  factory :wiki_editor, parent: :user do
-    verified { true }
-  end
-
-  factory :non_wiki_editor, parent: :user do
-    verified { false }
+  factory :vip, parent: :user do
+    state { "vip" }
   end
 
   factory :newbie, parent: :user do
@@ -34,11 +29,11 @@ FactoryBot.define do
 
   factory :blocked_user, parent: :user do
     created_at { 30.days.ago }
-    state { 2 }
+    state { "blocked" }
   end
 
   factory :deleted_user, parent: :user do
     created_at { 100.days.ago }
-    state { -1 }
+    state { "deleted" }
   end
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -54,8 +54,8 @@ class ApplicationHelperTest < ActionView::TestCase
   end
 
   test "wiki_editor?" do
-    non_editor = create :non_wiki_editor
-    editor = create :wiki_editor
+    non_editor = create :user
+    editor = create :vip
 
     # knows non editor is not wiki editor
     assert_equal false, wiki_editor?(non_editor)

--- a/test/helpers/users_helper_test.rb
+++ b/test/helpers/users_helper_test.rb
@@ -67,31 +67,14 @@ class UsersHelperTest < ActionView::TestCase
     assert_equal img, user_avatar_tag(user, :md, timestamp: true, link: false)
   end
 
-  test "render_user_level_tag admin should work" do
-    user = create(:user)
+  test "user_level_tag admin should work" do
+    user = User.new(created_at: 30.days.ago)
 
-    # admin
-    user.stub(:admin?, true) do
-      assert_equal '<span class="badge badge-danger role">管理员</span>', render_user_level_tag(user)
+    %w[admin vip hr maintainer blocked deleted newbie member].each do |level|
+      user.stub(:level, level) do
+        assert_equal %(<span class="badge-role role-#{level}" style="background: #{user.level_color};">#{user.level_name}</span>), user_level_tag(user)
+      end
     end
-
-    # vip
-    user.stub(:verified?, true) do
-      assert_equal '<span class="badge badge-success role">高级会员</span>', render_user_level_tag(user)
-    end
-
-    # blocked
-    user.stub(:blocked?, true) do
-      assert_equal '<span class="badge badge-warning role">禁言用户</span>', render_user_level_tag(user)
-    end
-
-    # newbie
-    user.stub(:newbie?, true) do
-      assert_equal '<span class="badge badge-light role">新手</span>', render_user_level_tag(user)
-    end
-
-    # normal
-    assert_equal '<span class="badge badge-info role">会员</span>', render_user_level_tag(user)
   end
 
   test "reward_user_tag" do

--- a/test/models/ability_test.rb
+++ b/test/models/ability_test.rb
@@ -21,6 +21,7 @@ class AbilityTest < ActiveSupport::TestCase
     user = create :user, state: :maintainer
     ability = Ability.new(user)
     assert ability.can?(:manage, Topic)
+    assert ability.can?(:lock_node, Topic)
     assert ability.can?(:manage, Reply)
     assert ability.can?(:manage, Section)
     assert ability.can?(:manage, Node)

--- a/test/models/ability_test.rb
+++ b/test/models/ability_test.rb
@@ -17,6 +17,16 @@ class AbilityTest < ActiveSupport::TestCase
     assert ability.can?(:manage, TeamUser)
   end
 
+  test "Maintainer manage Topic, Node" do
+    user = create :user, state: :maintainer
+    ability = Ability.new(user)
+    assert ability.can?(:manage, Topic)
+    assert ability.can?(:manage, Reply)
+    assert ability.can?(:manage, Section)
+    assert ability.can?(:manage, Node)
+    assert ability.can?(:create, Team)
+  end
+
   test "Vip manage wiki" do
     vip = create :vip
     ability = Ability.new(vip)

--- a/test/models/ability_test.rb
+++ b/test/models/ability_test.rb
@@ -17,16 +17,16 @@ class AbilityTest < ActiveSupport::TestCase
     assert ability.can?(:manage, TeamUser)
   end
 
-  test "Wiki Editor manage wiki" do
-    wiki_editor = create :wiki_editor
-    ability = Ability.new(wiki_editor)
+  test "Vip manage wiki" do
+    vip = create :vip
+    ability = Ability.new(vip)
 
     assert ability.cannot?(:suggest, Topic)
     assert ability.cannot?(:unsuggest, Topic)
     assert ability.can?(:create, Team)
   end
 
-  test "Normal users" do
+  test "Member" do
     user = create :avatar_user
     topic = create :topic, user: user
     topic1 = create :topic

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -49,18 +49,7 @@ class SettingTest < ActiveSupport::TestCase
   test "admin_emails" do
     assert_equal ["admin@admin.com"], Setting.admin_emails
     Setting.admin_emails = "admin@admin.com a0@foo.com\r\na1@foo.com\na2@foo.com\ra3@foo.com,a4@foo.com"
-    assert_equal false, Setting.has_admin?("huacnlee@gmail.com")
-    assert_equal true, Setting.has_admin?("admin@admin.com")
-    assert_equal true, Setting.has_admin?("a0@foo.com")
-    assert_equal true, Setting.has_admin?("a1@foo.com")
-    assert_equal true, Setting.has_admin?("a2@foo.com")
-    assert_equal true, Setting.has_admin?("a3@foo.com")
-    assert_equal true, Setting.has_admin?("a4@foo.com")
-    assert_equal false, Setting.has_admin?("a5@foo.com")
-
-    Setting.stubs(:admin_emails).returns(["foo@bar.com\n", "foo1@bar.com "])
-    assert_equal true, Setting.has_admin?("foo@bar.com")
-    assert_equal true, Setting.has_admin?("foo1@bar.com")
+    assert_equal ["admin@admin.com", "a0@foo.com", "a1@foo.com", "a2@foo.com", "a3@foo.com", "a4@foo.com"], Setting.admin_emails
   end
 
   test "modules" do

--- a/test/support/api_controller_test.rb
+++ b/test/support/api_controller_test.rb
@@ -19,8 +19,8 @@ class APIControllerTest < ActionDispatch::IntegrationTest
   end
 
   def login_admin!
+    @current_user.update!(state: :admin)
     login_user!
-    User.any_instance.stubs(:admin?).returns(true)
   end
 
   def default_headers


### PR DESCRIPTION
1. 管理员权限通过用户设置来修改，代替之前的 admin_emails 的方式；
2. 新增前台版主权限，版主拥有对前台内容的管理权限；
3. 新增 HR 角色，HR 角色允许直接发帖；
