### PR TITLE
markdown中换行无效，不会被转换成<br>标签

### DIFF
--- a/lib/homeland/pipeline/markdown_filter.rb
+++ b/lib/homeland/pipeline/markdown_filter.rb
@@ -9,7 +9,6 @@ module Homeland
     class MarkdownFilter < HTML::Pipeline::TextFilter
       DEFAULT_OPTIONS = {
         no_styles: true,
-        hard_wrap: true,
         autolink: true,
         fenced_code_blocks: true,
         strikethrough: true,
@@ -37,7 +36,7 @@ module Homeland
 
         class << self
           def to_html(raw)
-            renderer = self.new
+            renderer = self.new(hard_wrap: true)
             renderer.domain = Setting.domain
             @render ||= Redcarpet::Markdown.new(renderer, DEFAULT_OPTIONS)
             @render.render(raw)


### PR DESCRIPTION
在markdown如果输入

```
aaaa
bbb
```

会被渲染成`<p>aaa bbb</p>`，中间缺少`<br>`标签。

经过查阅[文档](https://github.com/vmg/redcarpet/#darling-i-packed-you-a-couple-renderers-for-lunch)后，发现`hard_wrap`参数放错了位置。

应当是在`Redcarpet::Render::HTML.new()`中，而不是`Redcarpet::Markdown.new`中

调整参数位置后，现在可以渲染成：

```
<p>aaa<br>bbb</p>
```