### PR TITLE
Bump to new jieba-rb which based on cppjieba v5.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "webpacker", "~> 5.x"
 gem "sanitize"
 
 gem "pg"
-gem "jieba_rb"
+gem "jieba-rb"
 gem "pghero"
 
 gem "dotenv-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,10 +64,10 @@ GEM
       nokogiri (~> 1.6)
       rest-client (~> 2.0)
     ast (2.4.1)
-    auto-correct (0.3.0)
+    auto-correct (0.3.1)
       nokogiri (>= 1.4)
-    bcrypt (3.1.13)
-    bootsnap (1.4.6)
+    bcrypt (3.1.15)
+    bootsnap (1.4.7)
       msgpack (~> 1.0)
     builder (3.2.4)
     bulk_insert (1.8.1)
@@ -90,7 +90,7 @@ GEM
     carrierwave-upyun (1.0.5)
       carrierwave (>= 1.0.0)
       faraday (>= 0.8.0)
-    codecov (0.2.1)
+    codecov (0.2.5)
       colorize
       json
       simplecov
@@ -147,7 +147,7 @@ GEM
     ffi (1.13.1)
     form-select (0.3.2)
       rails (>= 4.2)
-    fugit (1.3.6)
+    fugit (1.3.8)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.3)
     get_process_mem (0.2.5)
@@ -165,14 +165,14 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http_accept_language (2.1.1)
-    i18n (1.8.4)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     image_processing (1.11.0)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
-    jieba_rb (0.0.5)
+    jieba-rb (5.0.0)
     json (2.3.1)
     jwt (2.2.1)
     kaminari (1.2.1)
@@ -252,7 +252,7 @@ GEM
     parser (2.7.1.4)
       ast (~> 2.4.1)
     pg (1.2.3)
-    pghero (2.6.0)
+    pghero (2.7.0)
       activerecord (>= 5)
     postmark (1.21.1)
       json
@@ -339,7 +339,7 @@ GEM
       netrc (~> 0.8)
     rexml (3.2.4)
     rouge (3.21.0)
-    rubocop (0.88.0)
+    rubocop (0.89.0)
       parallel (~> 1.10)
       parser (>= 2.7.1.1)
       rainbow (>= 2.2.2, < 4.0)
@@ -348,8 +348,8 @@ GEM
       rubocop-ast (>= 0.1.0, < 1.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.1.0)
-      parser (>= 2.7.0.1)
+    rubocop-ast (0.3.0)
+      parser (>= 2.7.1.4)
     ruby-progressbar (1.10.1)
     ruby-push-notifications (1.3.0)
       builder (~> 3.0)
@@ -377,7 +377,7 @@ GEM
       activerecord (>= 5.2, < 7)
       activesupport (>= 5.2, < 7)
     semantic_range (2.3.0)
-    sidekiq (6.1.0)
+    sidekiq (6.1.1)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
@@ -454,7 +454,7 @@ DEPENDENCIES
   html-pipeline-auto-correct
   http_accept_language
   jbuilder
-  jieba_rb
+  jieba-rb
   kaminari
   letter_opener
   listen


### PR DESCRIPTION
去年带了[一个实习生做的这个项目](https://github.com/Xu-Zhiqing/jieba_rb)，已经升级到cppjieba 5.0.0，相比原版，支持自定义字典。