### PR TITLE
 feat: Append missing denpendencies.

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -2,7 +2,7 @@ FROM swipesense/ruby-jemalloc:2.7-buster-slim
 
 RUN gem install bundler
 RUN apt-get update &&  \
-  apt-get install -y ca-certificates nodejs curl git htop tzdata imagemagick nginx libnginx-mod-http-image-filter libnginx-mod-http-geoip  \
+  apt-get install -y ca-certificates nodejs cron socat curl git htop tzdata imagemagick nginx libnginx-mod-http-image-filter libnginx-mod-http-geoip  \
   build-essential ruby-dev openssl libpq-dev libxml2-dev libxslt-dev && \
   curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \


### PR DESCRIPTION
If we want to install acme.sh by 

```
curl https://get.acme.sh | sh
```

we also need

**cron**

![image](https://user-images.githubusercontent.com/8858472/89144698-06cfca80-d581-11ea-81a3-55b0c0fe9a8d.png)


**socat(Optional)**

![image](https://user-images.githubusercontent.com/8858472/89144876-92495b80-d581-11ea-8d8a-da5c8d8689b4.png)

Otherwise, the commend *RUN curl https://get.acme.sh | sh* will not be run. `acme.sh` can be absent, while running `sudo make install_ssl`.
