### PR TITLE
Style the resize grabber of textarea

### DIFF
--- a/app/javascript/homeland/index.scss
+++ b/app/javascript/homeland/index.scss
@@ -50,8 +50,6 @@ input[type="file"]::-webkit-file-upload-button {
 
 textarea,
 #preview {
-  overflow: scroll;
-
   &::-webkit-scrollbar {
     width: 12px;
   }


### PR DESCRIPTION
暗黑模式下 textarea 的调整大小的滑块仍为白色。

修改前：

![before](https://user-images.githubusercontent.com/16432276/89256807-816b1980-d657-11ea-86c9-c62e73be30ce.png)

修改后：

![after](https://user-images.githubusercontent.com/16432276/89256824-892abe00-d657-11ea-9db5-cf162d859eb9.png)