### PR TITLE
 hotfix: Fix 406 issue while submiting reply by key combinations.

### DIFF
--- a/app/javascript/front/topics.js
+++ b/app/javascript/front/topics.js
@@ -246,7 +246,9 @@ window.TopicView = Backbone.View.extend({
 
   submitTextArea(e) {
     if ($(e.target).val().trim().length > 0) {
-      $("form#new_reply").submit();
+      // “Note the data-remote="true". Now, the form will be submitted by Ajax rather than by the browser's normal submit mechanism.”
+      // So we need to send ajax submit here.
+      $("form#new_reply #reply-button").click();
     }
     return false;
   },


### PR DESCRIPTION
While submitting reply by `Command + Enter`, I will get this error

![image](https://user-images.githubusercontent.com/8858472/89917776-c977d680-dc2b-11ea-81f3-c43dcef57ad2.png)
