### PR TITLE
 fix: link to right path when login of team was update failed

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -37,6 +37,8 @@ class TeamsController < ApplicationController
     if @team.update(team_params)
       redirect_to(edit_team_path(@team), notice: t("common.update_success"))
     else
+      # 转向正确的拼写
+      @team.login = @team.login_was || @team.login
       render action: "edit"
     end
   end


### PR DESCRIPTION
 - 当含有非法字符串时，user_path 报错
 - 当改为已存在的login时，user_path 错误，操作时提示无权限访问

![image](https://user-images.githubusercontent.com/10846369/92332001-1759f000-f0ad-11ea-8aa8-74b158488939.png)

![image](https://user-images.githubusercontent.com/10846369/92331999-14f79600-f0ad-11ea-852d-2dc9fe769e97.png)
