### PR TITLE
帖子回复中增加一个连接为楼层的锚点

### DIFF
--- a/app/views/replies/_reply.html.erb
+++ b/app/views/replies/_reply.html.erb
@@ -23,6 +23,7 @@
             <span class="sub-info">
               <span class='floor'>#<%= floor %></span> ·
               <a class="time" href="#reply-<%= reply.id %>"><%= timeago(reply.created_at) %></a>
+              <a href="#reply<%= floor %>"> </a>
             </span>
             <span class="opts pull-right">
               <% if !reply.deleted? %>


### PR DESCRIPTION
topic_title_tag 构建的锚点是楼层，所以帖子回复中需要增加一个楼层锚点，这样从通知列表点连接才以跳转到正确的位置

see also: https://github.com/ruby-china/homeland/blob/master/app/helpers/topics_helper.rb#L41