### PR TITLE
用Ruby China RubyGems 镜像加速依赖安装过程

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN mkdir -p /home/app &&\
 
 ADD Gemfile Gemfile.lock package.json yarn.lock /home/app/homeland/
 RUN gem install puma
+RUN bundle config mirror.https://rubygems.org https://gems.ruby-china.com
 RUN bundle config set deployment 'true' && bundle install && yarn &&\
   find /home/app/homeland/vendor/bundle -name tmp -type d -exec rm -rf {} +
 ADD . /home/app/homeland


### PR DESCRIPTION
不加镜像构建慢到超时
https://github.com/ruby-china/homeland/issues/1236