### PR TITLE
change dark mode search placeholder color to white

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,7 +55,7 @@
         <div class="ml-auto d-flex navbar-right">
           <form class="navbar-form d-none d-lg-flex mr-2 form-search active" action="/search" method="GET">
             <i class="fa btn-search fa-search"></i>
-            <input type="text" name="q" class="form-control" value="<%= params[:q] %>" placeholder="搜索"></input>
+            <input type="text" name="q" class="form-control text-white" value="<%= params[:q] %>" placeholder="搜索"></input>
         </form>
         <%= render "shared/usernav" %>
       </div>


### PR DESCRIPTION
Dark Mode下主页搜索的placeholder改成text-white，这样能看清