### PR TITLE
Fix I18n auto_locale for JavaScript

### DIFF
--- a/app/controllers/application_controller/localize.rb
+++ b/app/controllers/application_controller/localize.rb
@@ -5,6 +5,8 @@ class ApplicationController
     extend ActiveSupport::Concern
 
     included do
+      helper_method :user_locale
+
       around_action :set_time_zone
       before_action :set_locale
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
     <meta charset='utf-8' />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
     <meta name="theme" content="<%= user_theme %>">
-    <meta name="locale" content="<%= Setting.default_locale %>">
+    <meta name="locale" content="<%= user_locale %>">
     <title><%= content_for?(:title) ? yield(:title) : Setting.app_name %></title>
     <meta name="apple-mobile-web-app-capable" content="no">
     <meta content='True' name='HandheldFriendly' />


### PR DESCRIPTION
忘了考虑设置里的 `Setting.auto_locale` 了。