### PR TITLE
RecordNotFound not use not_found status

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,8 +21,8 @@ class ApplicationController < ActionController::Base
 
   rescue_from ActiveRecord::RecordNotFound do |exception|
     respond_to do |format|
-      format.json { head :not_found }
-      format.html { render "/errors/404", status: :not_found }
+      format.json { head status }
+      format.html { render "/errors/404", status: status }
     end
   end
 


### PR DESCRIPTION
关于进入错误页面出现 `turbolinks` 问题，[Tipoc 链接](https://ruby-china.org/topics/41051)

原因：当全局捕获到 `ActiveRecord::RecordNotFound` 这个错误的时候，会返回 `:not_found` 的状态码，我搜了一下 turbolinks 好像没有对 `3xx`、`4xx` 以及 `5xx` 做处理。

直到我看到[这个评论](https://github.com/turbolinks/turbolinks/issues/179#issuecomment-349218396)，在 Rails 中重定向其实也会出现上面这种问题，但是 gem turbolinks 的解决方式是把状态码直接改成了 `200` [详见这里](https://github.com/turbolinks/turbolinks-rails/blob/4fffc808b437936808f0888a87b1a1ae1bbcb1cd/lib/turbolinks/redirection.rb#L33)， 我在想 homeland 里面如果捕获到 ActiveRecord::RecordNotFound 这种错误的时候，是否能够也直接使用 2xx 的状态码。

现在其实也只修改了 ActiveRecord::RecordNotFound 这个异常返回的状态码，对于进入 `render_optional_error_file` 这个方法里面的状态码没有做处理，依然会出现上面的问题

😄 哈哈，有认知错误的地方还希望大佬指正下