### PR TITLE
Fixed container layout caused by force set grid padding

### DIFF
--- a/app/javascript/front/users.scss
+++ b/app/javascript/front/users.scss
@@ -266,7 +266,6 @@ table.node-topics {
 }
 
 .sidebar {
-  padding-right: 0;
   .profile {
     .avatar {
       .media-object {

--- a/app/javascript/homeland/index.scss
+++ b/app/javascript/homeland/index.scss
@@ -532,10 +532,6 @@ input[type="file"] {
   }
 }
 
-.sidebar.col-lg-3 {
-  padding-left: 0;
-}
-
 .nav-tabs {
   li:first-child {
     margin-left: 15px;


### PR DESCRIPTION
Force set bootstrap grid gap caused problems:

1. Container width expand bigger unexpectedly
2. Grid gutters different between in some page.
3. Sidebar layout problem in mobile phone view. 


![Slice2](https://user-images.githubusercontent.com/39784/136243735-4541db8d-429a-4b2a-9e57-d45d39f6ec4e.png)

![Slice](https://user-images.githubusercontent.com/39784/136243093-0fae2e45-ca20-45c3-833e-bf1ceee8ec91.png)

![Slice3](https://user-images.githubusercontent.com/39784/136244004-4c331bcf-9717-43ba-a28e-679a2c588228.png)

