### PR TITLE
bundle update bootsnap to fix for ruby 3.0.3:

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
       nokogiri (>= 1.4)
     bcrypt (3.1.16)
     benchmark-ips (2.9.1)
-    bootsnap (1.8.1)
+    bootsnap (1.9.3)
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
@@ -537,4 +537,4 @@ DEPENDENCIES
   webpacker (= 6.0.0.rc.6)
 
 BUNDLED WITH
-   2.2.3
+   2.2.32


### PR DESCRIPTION
/home/runner/work/homeland/homeland/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.8.1/lib/bootsnap/compile_cache/iseq.rb:13:in `to_binary': wrong argument type false (expected Symbol) (TypeError)