### PR TITLE
Fix text color of search input in dark mode

### DIFF
--- a/app/javascript/homeland/index.scss
+++ b/app/javascript/homeland/index.scss
@@ -317,7 +317,7 @@ body {
       transition: all 0.3s;
       box-sizing: border-box;
       box-shadow: none !important;
-      color: #333;
+      color: var(--text-color1);
       &:focus {
         outline: none;
         border: none;


### PR DESCRIPTION
**Before**
<img width="1484" alt="Screenshot 2022-02-09 at 7 35 06 PM" src="https://user-images.githubusercontent.com/465125/153192166-651d3901-289e-41ca-a9f6-97bee9272762.png">

**After**
<img width="1484" alt="Screenshot 2022-02-09 at 7 35 30 PM" src="https://user-images.githubusercontent.com/465125/153192221-8de93595-855e-4350-aa1f-c35783e0ef37.png">

