### PR TITLE
Disable Turbo on pagination when clicking page number.

### DIFF
--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,9 +1,9 @@
 <% if page.current? %>
   <li class='page-item active'>
-    <%= content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: "page-link" %>
+    <%= content_tag :a, page, remote: remote, data: {turbo: false}, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: "page-link" %>
   </li>
 <% else %>
   <li class="page-item">
-    <%= link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: "page-link" %>
+    <%= link_to page, url, remote: remote, data: {turbo: false}, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: "page-link" %>
   </li>
 <% end %>


### PR DESCRIPTION
Sometimes when clicking on page number to go to the next (or specific) page, browser window won't scroll to top. 

This happens on desktop browser, after 4~5 page changes, e.g.: click page 1 (scroll to top), click page 2 (scroll to top), click page 3 (scroll to top), click page 4( !!remain at the bottom paginator, and not scrolling to top, but posts items has changed to page 4), click page 5 (scroll to top)...

This is annoying, because users have to manually scroll the mouse to the top of the page, to start browsing (unless he wishes to read bottom to top, and there isn't a paginator on the top so he has to scroll to bottom again to visit the next-next page).

By disabling Turbo on pagination of the Kaminari `_page` partial, the browser will always use a full page reload when users click on page number to go to the specific page. The window will always be at the top of the page when going to a new page, e.g.: from `https://ruby-china.org/?page=1` to `https://ruby-china.org/?page=2`. 

I haven't tested it on my machine for the Homeland repo, but it works with my other projects using Rails7 + Kaminari + Hotwire. I'd assume it should also work fine for Homeland.