### PR TITLE
Bump bootstrap to avoid autoprefixer warning:

### DIFF
--- a/app/javascript/homeland/bootstrap_custom.scss
+++ b/app/javascript/homeland/bootstrap_custom.scss
@@ -7,9 +7,10 @@
 
 // scss-docs-start import-stack
 // Configuration
+@import "~bootstrap/scss/mixins";
 @import "~bootstrap/scss/functions";
 @import "~bootstrap/scss/variables";
-@import "~bootstrap/scss/mixins";
+@import "~bootstrap/scss/maps";
 @import "~bootstrap/scss/utilities";
 
 // Layout & components

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "autoprefixer": "~10.4.17",
     "babel-loader": "8.2.5",
     "backbone": "~1.4",
-    "bootstrap": "~5.1.3",
+    "bootstrap": "~5.3.3",
     "bootstrap-select": "^1.14.0-beta2",
     "compression-webpack-plugin": "9",
     "css-loader": "^6.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1729,10 +1729,10 @@ bootstrap-select@^1.14.0-beta2:
   resolved "https://registry.npmmirror.com/bootstrap-select/-/bootstrap-select-1.14.0-beta3.tgz#dc15083fe51d0ac7b38a3b99dfd492dcc0a783b0"
   integrity sha512-wYUDY4NAYBcNydXybE7wh3+ucyf+AcUOhZ+e0TFIoZ38A+k/3BVT1RPl5f0CiPxAexP1IQuqALKMqI8wtZS71A==
 
-bootstrap@~5.1.3:
-  version "5.1.3"
-  resolved "https://registry.npmmirror.com/bootstrap/-/bootstrap-5.1.3.tgz#ba081b0c130f810fa70900acbc1c6d3c28fa8f34"
-  integrity sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==
+bootstrap@~5.3.3:
+  version "5.3.3"
+  resolved "https://registry.npmmirror.com/bootstrap/-/bootstrap-5.3.3.tgz#de35e1a765c897ac940021900fcbb831602bac38"
+  integrity sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
Replace color-adjust to print-color-adjust. The color-adjust shorthand is currently deprecated.

[The import sequence do matter](https://stackoverflow.com/a/76993430/262826)