### PR TITLE
Need downgrade to 5.2.3 because 5.3 introduce .card-body color

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "autoprefixer": "~10.4.17",
     "babel-loader": "8.2.5",
     "backbone": "~1.4",
-    "bootstrap": "~5.3.3",
+    "bootstrap": "~5.2.3",
     "bootstrap-select": "^1.14.0-beta2",
     "compression-webpack-plugin": "9",
     "css-loader": "^6.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1729,10 +1729,10 @@ bootstrap-select@^1.14.0-beta2:
   resolved "https://registry.npmmirror.com/bootstrap-select/-/bootstrap-select-1.14.0-beta3.tgz#dc15083fe51d0ac7b38a3b99dfd492dcc0a783b0"
   integrity sha512-wYUDY4NAYBcNydXybE7wh3+ucyf+AcUOhZ+e0TFIoZ38A+k/3BVT1RPl5f0CiPxAexP1IQuqALKMqI8wtZS71A==
 
-bootstrap@~5.3.3:
-  version "5.3.3"
-  resolved "https://registry.npmmirror.com/bootstrap/-/bootstrap-5.3.3.tgz#de35e1a765c897ac940021900fcbb831602bac38"
-  integrity sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==
+bootstrap@~5.2.3:
+  version "5.2.3"
+  resolved "https://registry.npmmirror.com/bootstrap/-/bootstrap-5.2.3.tgz#54739f4414de121b9785c5da3c87b37ff008322b"
+  integrity sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
.card-body { color: var(--bs-card-color); }

https://github.com/twbs/bootstrap/issues/38852

In PR #1411, we bumped to bootstrap 5.3, but it will lead Post content text not work in dark mode. (original dark:text-gray-100, but overwrite by card-body color)
