### PR TITLE
add login check and logout url

### DIFF
--- a/.env
+++ b/.env
@@ -44,6 +44,7 @@ mailer_options.enable_starttls_auto=true
 sso_enable=false
 sso_enable_provider=false
 sso_url=
+sso_logout_url=
 sso_secret=
 
 # [Upload Config]
@@ -56,3 +57,6 @@ upload_bucket=
 upload_aliyun_internal=
 upload_aliyun_area=
 upload_url=
+
+# [Access Control]
+logged_in_required=true

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,20 @@ class ApplicationController < ActionController::Base
   etag { Setting.footer_html }
   etag { Rails.env.development? ? Time.now : Date.current }
 
+  # Add login check
+  before_action :check_login_required
+
+  def check_login_required
+    return unless ENV['logged_in_required'] == 'true'
+    return if current_user
+    return if devise_controller?
+    return if controller_name == 'sso' && action_name == 'show'
+    return if controller_name == 'sso' && action_name == 'login'
+    
+    store_location
+    redirect_to new_user_session_path
+  end
+
   rescue_from ActiveRecord::RecordNotFound do |exception|
     respond_to do |format|
       format.json { head :not_found }

--- a/app/views/devise/menu/_login_items.html.erb
+++ b/app/views/devise/menu/_login_items.html.erb
@@ -1,5 +1,5 @@
 <% if user_signed_in? %>
-  <%= link_to(t("common.logout"), destroy_user_session_path) %>
+  <%= link_to(t("common.logout"), destroy_user_session_path, method: :delete) %>
 <% else %>
   <%= link_to(t("common.login"), new_user_session_path)  %>
 <% end %>


### PR DESCRIPTION
# Context
There is no login check function in the project, and after deployment, it is a fully developed forum

# What I changed
Added login check configuration "logged_in_required", the forum must be logged in to access. If not logged in, it will continue to jump to the login interface. This "logged_in_required" is optional. If it is equal to "true", it means the login check function is enabled. If it is equal to "false", the forum can be accessed without logging in.

At the same time, I set up a configuration called "sso_logout_url". If an SSO logout URL is set, the user will be redirected to that URL after logging out
